### PR TITLE
chore: bump to v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [1.8.0]: Version displayed on scan screen
+
+### Added
+- **Version on home screen**: the app version is now shown in small text below the title divider on the scan (home) screen, so the installed version is always visible at a glance
+
 ## [1.7.1]: Report version string fix
 
 ### Fixed

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.7.1"
+#define APP_VERSION "1.8.0"
 
 #include "access_audit.h"
 #include "core/observation.h"

--- a/application.fam
+++ b/application.fam
@@ -6,7 +6,7 @@ App(
     sources=["*.c"],
     requires=["gui", "nfc", "storage"],
     stack_size=2 * 1024,
-    fap_version=(1, 7),
+    fap_version=(1, 8),
     fap_icon="icon.png",
     fap_category="Tools",
     fap_author="matthewkayne",

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.7.1"
+#define REPORT_APP_VERSION "1.8.0"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {


### PR DESCRIPTION
## Summary

- Bumps `fap_version` to `(1, 8)` in `application.fam`
- Updates `REPORT_APP_VERSION` to `1.8.0` in `core/report.c`
- Updates `APP_VERSION` to `1.8.0` in `access_audit.c` (shown on scan screen)
- Adds v1.8.0 CHANGELOG entry

## Test plan

- [ ] CI builds and lint jobs green
- [ ] Scan screen shows "v1.8.0"
- [ ] Saved report header shows "Generated by Access Audit v1.8.0"
- [ ] Merge, manually test on Flipper, then tag `v1.8.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)