### PR TITLE
fix: handle CardDetected event in MfClassic poller callback

### DIFF
--- a/core/observation_provider.c
+++ b/core/observation_provider.c
@@ -539,6 +539,18 @@ static NfcCommand mf_classic_poller_cb(NfcGenericEvent event, void* context) {
         return NfcCommandContinue;
     }
 
+    /* Card detected event fires before the first RequestReadSector — let it pass. */
+    if(cl_event->type == MfClassicPollerEventTypeCardDetected) {
+        return NfcCommandContinue;
+    }
+
+    /* DataUpdate fires periodically during MfClassicPollerModeRead to report
+     * progress. We stop after sector 0 so it rarely fires, but handle it
+     * explicitly to avoid hitting the catch-all before sector 0 is reached. */
+    if(cl_event->type == MfClassicPollerEventTypeDataUpdate) {
+        return NfcCommandContinue;
+    }
+
     if(cl_event->type == MfClassicPollerEventTypeRequestReadSector &&
        cl_event->data->read_sector_request_data.sector_num == 0) {
         static const uint8_t DEFAULT_KEYS[][MF_CLASSIC_KEY_SIZE] = {
@@ -606,9 +618,11 @@ static NfcCommand mf_classic_poller_cb(NfcGenericEvent event, void* context) {
         return NfcCommandStop;
     }
 
-    /* Fail, CardLost, or any event before sector 0 is requested. */
+    /* CardLost, Fail, or any unhandled event — do not overwrite a successful result. */
     furi_mutex_acquire(p->mutex, FuriWaitForever);
-    p->state = ProviderStateReadFailed;
+    if(p->state != ProviderStateDone) {
+        p->state = ProviderStateReadFailed;
+    }
     furi_mutex_release(p->mutex);
     return NfcCommandStop;
 }


### PR DESCRIPTION
## Problem

MIFARE Classic 1K cards were not being read. Two issues found in \`mf_classic_poller_cb\`:

1. **\`MfClassicPollerEventTypeCardDetected\`** fires before the first \`RequestReadSector\` event in \`MfClassicPollerModeRead\`. It was hitting the catch-all handler which set \`ProviderStateReadFailed\` and returned \`NfcCommandStop\`, aborting the read before sector 0 was ever requested. This is the primary cause.

2. **\`MfClassicPollerEventTypeDataUpdate\`** fires periodically during a read and could also hit the catch-all if it fires before sector 0 is reached in an edge case.

3. **Catch-all** could overwrite \`ProviderStateDone\` if any event fired after a successful sector 0 result.

Identified by reviewing the NFC dump provided in the Flipper app catalog PR by reviewer xMasterX.

## Fix

- Handle \`CardDetected\` with \`NfcCommandContinue\`
- Handle \`DataUpdate\` with \`NfcCommandContinue\`
- Guard catch-all so it cannot overwrite \`ProviderStateDone\`

## Other pollers audited

- \`iso14443_3a_poller_cb\`: 2 event types, both handled exhaustively - clean
- \`mf_desfire_poller_cb\`: 2 event types, both handled exhaustively - clean
- \`mf_plus_poller_cb\`: 2 event types, both handled exhaustively - clean
- \`iso15693_3_poller_cb\`: reads data on both Ready and Error, no catch-all - clean
- \`felica_poller_cb\`: \`RequestAuthContext\` not handled but only fires in auth flows we never trigger - safe
- \`iclass_poller_cb\`: synchronous exchange within callback, no multi-event flow - clean

## Test plan

- [ ] CI green
- [ ] MIFARE Classic 1K card scans and produces a risk report
- [ ] Default key detection still works on Classic cards with default keys
- [ ] Other card types (DESFire, Ultralight, iCLASS) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)