### PR TITLE
chore: bump to v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [1.8.1]: MIFARE Classic scan fix
+
+### Fixed
+- **MIFARE Classic 1K/4K/Mini cards now scan correctly**: `MfClassicPollerEventTypeCardDetected` was hitting the catch-all handler and aborting the read before sector 0 was ever requested. Added explicit handling for `CardDetected` and `DataUpdate` events with `NfcCommandContinue`, and guarded the catch-all so it cannot overwrite a successful result
+
 ## [1.8.0]: Version displayed on scan screen
 
 ### Added

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.8.0"
+#define APP_VERSION "1.8.1"
 
 #include "access_audit.h"
 #include "core/observation.h"

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.8.0"
+#define REPORT_APP_VERSION "1.8.1"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {


### PR DESCRIPTION
## Summary

- Updates `APP_VERSION` to `1.8.1` in `access_audit.c`
- Updates `REPORT_APP_VERSION` to `1.8.1` in `core/report.c`
- Adds v1.8.1 CHANGELOG entry for the MIFARE Classic scan fix

## Test plan

- [ ] CI builds and lint jobs green
- [ ] MIFARE Classic 1K card scans correctly and shows v1.8.1 on screen
- [ ] Saved report header shows "Generated by Access Audit v1.8.1"
- [ ] Merge, manually test on Flipper, then tag `v1.8.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)