### PR TITLE
Expand MIFARE Classic default key dictionary (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented here.
 
+## [1.9.0]: Expanded MIFARE Classic default key dictionary
+
+### Changed
+- **MIFARE Classic default key check now covers 8 well-known public keys** (was 2) (#35): added the NXP MAD key A (`A0A1A2A3A4A5` was already present), the NFC Forum NDEF public key `D3F7D3F7D3F7`, the all-zero `000000000000`, and common vendor defaults `A0B0C0D0E0F0`, `A1B1C1D1E1F1`, `B0B1B2B3B4B5`, `AABBCCDDEEFF`, alongside the factory transport key `FFFFFFFFFFFF`. Each is tried as both key A and key B against sector 0, the loop stops at the first match, and the list is capped under 10 keys so the active auth scan stays fast. Key list documented in `docs/rules.md`
+
+### Added
+- **Default-key finding shown on the result screen**: when sector 0 authenticates with a default key, the result screen now shows "! Default key readable" in place of the controls hint, surfacing the active-scan finding on-device instead of only in the saved report
+
+### Fixed
+- Corrected the documented default-key scores: a MIFARE Classic 1K with default keys scores **75/100** (legacy 35 + identifier 35 + default_keys 15 − crypto1 10), not 65/100 as previously stated in `docs/rules.md` and `docs/scoring.md`; `docs/card-types.md` was also updated from stale pre-`crypto1_breakable` values (85/70) to the current 75/60
+
 ## [1.8.1]: MIFARE Classic scan fix
 
 ### Fixed

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.8.1"
+#define APP_VERSION "1.9.0"
 
 #include "access_audit.h"
 #include "core/observation.h"
@@ -376,8 +376,14 @@ static void access_audit_draw_callback(Canvas* canvas, void* context) {
     access_audit_format_uid_line(&app->obs, line, sizeof(line));
     canvas_draw_str(canvas, 2, 48, line);
 
-    /* Help row */
-    canvas_draw_str(canvas, 2, 62, "OK:rescan  Back:exit");
+    /* Bottom row: surface the active-scan default-key finding when present,
+     * otherwise show the controls hint. The finding is the more important
+     * signal and would otherwise only appear in the saved report. */
+    if(app->obs.default_keys_readable) {
+        canvas_draw_str(canvas, 2, 62, "! Default key readable");
+    } else {
+        canvas_draw_str(canvas, 2, 62, "OK:rescan  Back:exit");
+    }
 }
 
 static void access_audit_input_callback(InputEvent* input_event, void* context) {

--- a/application.fam
+++ b/application.fam
@@ -6,7 +6,7 @@ App(
     sources=["*.c"],
     requires=["gui", "nfc", "storage"],
     stack_size=2 * 1024,
-    fap_version=(1, 8),
+    fap_version=(1, 9),
     fap_icon="icon.png",
     fap_category="Tools",
     fap_author="matthewkayne",

--- a/core/observation_provider.c
+++ b/core/observation_provider.c
@@ -518,14 +518,12 @@ static NfcCommand mf_plus_poller_cb(NfcGenericEvent event, void* context) {
  * MfClassic poller callback  (runs on NFC worker thread)
  *
  * Uses MfClassicPollerModeRead. The poller fires RequestReadSector starting
- * from sector 0. On that event we manually call mf_classic_poller_auth with
- * two well-known default keys (FFFFFFFFFFFF and A0A1A2A3A4A5, both key types)
- * and record whether any succeeded. We then halt the card and stop — no full
- * sector read is performed and no card data is retained.
- *
- * Default keys checked (in order):
- *   FFFFFFFFFFFF key A, FFFFFFFFFFFF key B
- *   A0A1A2A3A4A5 key A, A0A1A2A3A4A5 key B
+ * from sector 0. On that event we manually call mf_classic_poller_auth against
+ * a list of well-known public keys (each tried as both key A and key B) and
+ * record whether any succeeded. We then halt the card and stop — no full sector
+ * read is performed and no card data is retained. The loop stops at the first
+ * key that authenticates. See DEFAULT_KEYS below for the full list (factory
+ * transport, NXP MAD, NFC Forum NDEF, and common vendor defaults).
  * -------------------------------------------------------------------------
  */
 
@@ -553,18 +551,30 @@ static NfcCommand mf_classic_poller_cb(NfcGenericEvent event, void* context) {
 
     if(cl_event->type == MfClassicPollerEventTypeRequestReadSector &&
        cl_event->data->read_sector_request_data.sector_num == 0) {
+        /* Well-known public MIFARE Classic keys checked against sector 0.
+         * Each is tried as both key A and key B. Kept under 10 so the auth
+         * loop stays fast; these cover the keys overwhelmingly seen in the
+         * field on cards that were never re-keyed. */
         static const uint8_t DEFAULT_KEYS[][MF_CLASSIC_KEY_SIZE] = {
-            {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, /* FFFFFFFFFFFF */
-            {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5}, /* A0A1A2A3A4A5 */
+            {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, /* FFFFFFFFFFFF — factory transport default */
+            {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5}, /* A0A1A2A3A4A5 — MAD key A (NXP AN10787)   */
+            {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7}, /* D3F7D3F7D3F7 — NFC Forum NDEF public key */
+            {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, /* 000000000000 — blanked / all-zero key    */
+            {0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0}, /* A0B0C0D0E0F0 — common vendor default      */
+            {0xA1, 0xB1, 0xC1, 0xD1, 0xE1, 0xF1}, /* A1B1C1D1E1F1 — common vendor default      */
+            {0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5}, /* B0B1B2B3B4B5 — common vendor default      */
+            {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}, /* AABBCCDDEEFF — common vendor default      */
         };
         static const MfClassicKeyType KEY_TYPES[] = {MfClassicKeyTypeA, MfClassicKeyTypeB};
+        const size_t num_keys = sizeof(DEFAULT_KEYS) / sizeof(DEFAULT_KEYS[0]);
+        const size_t num_key_types = sizeof(KEY_TYPES) / sizeof(KEY_TYPES[0]);
 
         MfClassicPoller* cl_poller = (MfClassicPoller*)event.instance;
         MfClassicAuthContext auth_ctx;
         bool default_key_found = false;
 
-        for(size_t k = 0; k < 2 && !default_key_found; k++) {
-            for(size_t t = 0; t < 2 && !default_key_found; t++) {
+        for(size_t k = 0; k < num_keys && !default_key_found; k++) {
+            for(size_t t = 0; t < num_key_types && !default_key_found; t++) {
                 MfClassicKey key;
                 memcpy(key.data, DEFAULT_KEYS[k], MF_CLASSIC_KEY_SIZE);
                 MfClassicError err =

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.8.1"
+#define REPORT_APP_VERSION "1.9.0"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {

--- a/docs/card-types.md
+++ b/docs/card-types.md
@@ -31,7 +31,7 @@ All 125 kHz RFID cards trigger `legacy_family` and `identifier_only_pattern`. Th
 
 Crypto1 has been publicly broken since 2008 (CRYPTO1 attacks, Darkside, Nested). Any MIFARE Classic deployment should be treated as compromised.
 
-When a Classic card is scanned, the app actively attempts to authenticate sector 0 using common default keys (`FFFFFFFFFFFF` and `A0A1A2A3A4A5`). If either succeeds, the `default_keys` rule fires and the report includes an explicit note. A card with default keys scores 85/100 instead of the standard 70/100.
+When a Classic card is scanned, the app actively attempts to authenticate sector 0 against a set of well-known public keys (factory transport, NXP MAD, NFC Forum NDEF, and common vendor defaults — see [rules.md](rules.md#active-scan-findings) for the full list). If any succeeds, the `default_keys` rule fires (+15) and the report includes an explicit note. A Classic 1K with default keys scores 75/100 instead of the standard 60/100.
 
 ---
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -72,13 +72,19 @@ UID could not be extracted. The observation cannot be fully assessed.
 
 ### `default_keys`
 
-Fires when sector 0 on a MIFARE Classic card was authenticated using a well-known default key. Indicates the card keys have never been changed from factory defaults.
+Fires when sector 0 on a MIFARE Classic card was authenticated using a well-known public key. Indicates the card keys have never been changed from a publicly documented default.
 
 Keys checked (key A and key B for each):
-- `FFFFFFFFFFFF` - factory default for all sectors on a new card
-- `A0A1A2A3A4A5` - common key A default in NXP reference deployments
+- `FFFFFFFFFFFF` - factory transport default for all sectors on a new card
+- `A0A1A2A3A4A5` - MAD key A (NXP AN10787 application directory)
+- `D3F7D3F7D3F7` - NFC Forum NDEF public key
+- `000000000000` - blanked / all-zero key
+- `A0B0C0D0E0F0` - common vendor default
+- `A1B1C1D1E1F1` - common vendor default
+- `B0B1B2B3B4B5` - common vendor default
+- `AABBCCDDEEFF` - common vendor default
 
-This rule requires an active authentication attempt. A note is written to the report indicating the finding came from an active scan.
+The list is intentionally capped (under 10 keys) so the active auth loop completes quickly. The check stops at the first key that authenticates. This rule requires an active authentication attempt. A note is written to the report indicating the finding came from an active scan.
 
 **Score contribution:** +15 · **Max severity:** HIGH
 
@@ -134,7 +140,7 @@ Matches:
 |---|---|---|---|
 | EM4100 | legacy_family, identifier_only_pattern | 70 | HIGH RISK |
 | MIFARE Classic 1K | legacy_family, identifier_only_pattern, crypto1_breakable | 60 | HIGH RISK |
-| MIFARE Classic 1K (default keys) | legacy_family, identifier_only_pattern, default_keys, crypto1_breakable | 65 | HIGH RISK |
+| MIFARE Classic 1K (default keys) | legacy_family, identifier_only_pattern, default_keys, crypto1_breakable | 75 | HIGH RISK |
 | MIFARE Plus SL1 | legacy_family, identifier_only_pattern | 70 | HIGH RISK |
 | HID iCLASS Legacy 2k | legacy_family, identifier_only_pattern | 70 | HIGH RISK |
 | MIFARE Plus SL2 | identifier_only_pattern, modern_crypto | 15 | MODERATE |

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -89,7 +89,7 @@ If both `modern_crypto` and `legacy_family` fire simultaneously (which cannot ha
 
 **Result: HIGH RISK · 60/100**
 
-> If sector 0 authenticates with a default key, `default_keys` also fires (+15), raising the score to 65/100.
+> If sector 0 authenticates with a default key, `default_keys` also fires (+15), raising the score to 75/100.
 
 ---
 


### PR DESCRIPTION
## Summary

Expands the MIFARE Classic active default-key check and surfaces the finding on-device.

- **Default-key dictionary 2 → 8 keys** (#35): adds the NXP MAD key A, NFC Forum NDEF public key `D3F7D3F7D3F7`, all-zero `000000000000`, and common vendor defaults (`A0B0C0D0E0F0`, `A1B1C1D1E1F1`, `B0B1B2B3B4B5`, `AABBCCDDEEFF`) alongside the factory transport key `FFFFFFFFFFFF`. Each is tried as both key A and key B against sector 0, the loop stops at the first match, and the list is capped under 10 keys so the active scan stays fast. Loop bounds derive from the array size so they can't drift.
- **UI**: the result screen now shows `! Default key readable` in place of the controls hint when the finding fires — previously it only appeared in the saved report.
- **Docs fix**: corrected stale default-key scores — a Classic 1K with default keys is **75/100** (legacy 35 + identifier 35 + default_keys 15 − crypto1 10), not 65/100 (`rules.md`/`scoring.md`); `card-types.md` updated from pre-`crypto1_breakable` values (85/70) to 75/60.

No change to `scoring.c` — the expanded dictionary rides the existing `default_keys` rule (+15).

## Not in this PR

`#33` (Ultralight default-password check) is intentionally **held** pending hardware verification — changing `skip_auth` could regress reads on cards protected with a non-default password, and the SDK ships headers only so the auth-failure behavior can't be confirmed without a device.

## Verification

- `ufbt` build: clean
- clang-format + cppcheck: pass
- `fap_version=(1,9)` ↔ `APP_VERSION`/`REPORT_APP_VERSION` `1.9.0` — release version gate will pass for tag `v1.9.0`

Closes #35
