### PR TITLE
ci: automate commit_sha bump + catalog PR after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,84 @@ jobs:
             dist/access_audit.fap.sha256
           generate_release_notes: true
           fail_on_unmatched_files: true
+
+  # ── Post-release automation ────────────────────────────────────────────────
+  # Both jobs are gated on the RELEASE_AUTOMATION repo variable so a missing PAT
+  # never fails the release itself. They use github.sha — on a tag push that is
+  # the tagged release commit. To enable: set repo variable RELEASE_AUTOMATION=true
+  # and add secret RELEASE_PAT (a token owned by the repo owner, contents+PR write
+  # on flipper-access-audit and the flipper-application-catalog fork, able to push
+  # to the PR-protected main branch). See CLAUDE.md §6.
+
+  update-manifest-sha:
+    name: Update manifest.yml commit_sha
+    needs: build-and-release
+    if: ${{ vars.RELEASE_AUTOMATION == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.RELEASE_PAT }}
+
+      # The catalog reads its own manifest (see catalog-pr below); this keeps the
+      # source repo's manifest.yml commit_sha as an accurate record of the release.
+      - name: Point manifest.yml commit_sha at the release commit
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          sed -i -E "s/(commit_sha:[[:space:]]*).*/\1${RELEASE_SHA}/" manifest.yml
+          if git diff --quiet manifest.yml; then
+            echo "commit_sha already current — nothing to push"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: point manifest.yml commit_sha at ${TAG}"
+          git push origin HEAD:main
+
+  catalog-pr:
+    name: Open catalog update PR
+    needs: build-and-release
+    # Catalog versions are MAJOR.MINOR only, so only minor/major releases (vX.Y.0)
+    # warrant a submission; a patch release (vX.Y.1+) is a duplicate catalog version.
+    if: ${{ vars.RELEASE_AUTOMATION == 'true' && endsWith(github.ref_name, '.0') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout catalog fork
+        uses: actions/checkout@v6
+        with:
+          repository: matthewkayne/flipper-application-catalog
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Bump commit_sha in the catalog manifest and open the PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          RELEASE_SHA: ${{ github.sha }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add upstream https://github.com/flipperdevices/flipper-application-catalog.git
+          git fetch upstream main
+          BRANCH="matthewkayne/access_audit_${TAG#v}"
+          git checkout -B "$BRANCH" upstream/main
+          # The catalog entry lives here and uses .yaml (not .yml) — see CLAUDE.md §6.
+          MANIFEST="applications/Tools/access_audit/manifest.yaml"
+          sed -i -E "s/(commit_sha:[[:space:]]*).*/\1${RELEASE_SHA}/" "$MANIFEST"
+          if git diff --quiet "$MANIFEST"; then
+            echo "catalog commit_sha already current — nothing to submit"
+            exit 0
+          fi
+          git commit -am "Access Audit: update to ${TAG}"
+          git push -f origin "$BRANCH"
+          gh pr create \
+            --repo flipperdevices/flipper-application-catalog \
+            --base main \
+            --head "matthewkayne:${BRANCH}" \
+            --title "[Tools] Access Audit ${TAG}" \
+            --body "Updates Access Audit to ${TAG}. Pins \`commit_sha\` to \`${RELEASE_SHA}\` (release: https://github.com/matthewkayne/flipper-access-audit/releases/tag/${TAG})." \
+            || echo "PR already exists or could not be created — check manually"


### PR DESCRIPTION
## Summary

Automates the two post-release chores so they no longer have to be done by hand.

Adds two jobs to `release.yml`, chained after `build-and-release` on every `vX.Y.Z` tag:

- **`update-manifest-sha`** — points the source `manifest.yml` `commit_sha` at the release commit and pushes to `main` (record-keeping).
- **`catalog-pr`** — on `vX.Y.0` tags only (catalog versions are MAJOR.MINOR, so patches would be a duplicate): bumps `commit_sha` in the catalog fork's `applications/Tools/access_audit/manifest.yaml` (branched off `upstream/main`) and opens a PR to `flipperdevices/flipper-application-catalog`.

Why jobs in `release.yml` (not a separate `on: release` workflow): a release created by `GITHUB_TOKEN` does not trigger downstream workflows. Chaining with `needs:` runs them in the same tag-push run, which a real push *does* trigger.

## Required setup before this does anything

Both jobs are **gated on the `RELEASE_AUTOMATION` repo variable**, so until it's set they skip and releases are unaffected.

1. Repo **variable** `RELEASE_AUTOMATION` = `true`
2. Repo **secret** `RELEASE_PAT` = a token owned by `matthewkayne` with `repo` scope across `flipper-access-audit` **and** the catalog fork, able to **bypass the `main` ruleset** (the default `github-actions[bot]` token cannot push to `main`).

## Notes / findings

- The **catalog reads its own `manifest.yaml`** (`.yaml`, `@docs/catalog-description.md`) in the catalog repo — the source repo's `manifest.yml` (`.yml`, `@README.md`) is just a record. Documented in CLAUDE.md §6; only the catalog file affects what's published.
- `actionlint` passes on all workflows.

No app/build/lint behavior changes — workflow-only.
