### PR TITLE
feat: OWASP Risk Rating likelihood framing + cite OWASP RRM (v1.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented here.
 
+## [1.10.0]: OWASP Risk Rating Methodology framing
+
+### Changed
+- **Reports now frame the score as a LIKELIHOOD-of-compromise rating aligned with the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology)**. Each card entry now shows `Likelihood: <HIGH/MODERATE/LOW/MINIMAL> (N/100, confidence N%)` plus an `Ease of exploit: <trivial/moderate/hard>` factor (OWASP's likelihood factor, derived from the credential technology). The report header carries a methodology note and cites OWASP RRM, and states explicitly that this tool rates **likelihood only** — **impact** (what the credential protects) is assessed in engagement context. The numeric scoring engine is unchanged; only the framing/labels are OWASP-aligned
+- Session advisory reworded in likelihood terms ("N credential(s) with HIGH likelihood of compromise") and prompts the operator to assess impact in context
+
+### Added
+- `likelihood_label()` and `ease_of_exploit()` helpers in `scoring.c` mapping severity → OWASP likelihood band and credential → OWASP "Ease of Exploit" factor
+- Documentation (`docs/scoring.md`, `docs/rules.md`, `docs/card-types.md`, README, catalog description) now explains and cites the OWASP RRM alignment
+
 ## [1.9.0]: Expanded MIFARE Classic default key dictionary
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ ufbt
 
 ### Score interpretation
 
-| Label | Score | Meaning |
+The score is a **likelihood-of-compromise** rating aligned with the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology) (`Risk = Likelihood × Impact`). It rates **likelihood only** — how easily the credential can be cloned or its secret recovered. **Impact** (what the credential protects) is assessed in engagement context. Saved reports show a per-card `Likelihood` band plus an `Ease of exploit` factor and cite OWASP RRM.
+
+| Label | Score | Likelihood of compromise |
 |---|---|---|
-| HIGH RISK | 35-100 | Legacy family (MIFARE Classic, EM4100, HID iCLASS, Plus SL1) or static-replay pattern |
-| MODERATE | 20-34 | Risk indicators present; review recommended |
+| HIGH RISK | 35-100 | Legacy family (MIFARE Classic, EM4100, HID iCLASS, Plus SL1) or static-replay pattern — trivial to clone |
+| MODERATE | 20-34 | Broken/known crypto; active attack or known-key tooling needed |
 | LOW RISK | 10-19 | Minor concerns, e.g. incomplete metadata |
-| SECURE | 0-9 | Modern crypto family with no major findings |
+| SECURE | 0-9 | Modern crypto family, no public break — hard to compromise |
 
 ### Card classification depth
 

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.9.0"
+#define APP_VERSION "1.10.0"
 
 #include "access_audit.h"
 #include "core/observation.h"

--- a/application.fam
+++ b/application.fam
@@ -6,7 +6,7 @@ App(
     sources=["*.c"],
     requires=["gui", "nfc", "storage"],
     stack_size=2 * 1024,
-    fap_version=(1, 9),
+    fap_version=(1, 10),
     fap_icon="icon.png",
     fap_category="Tools",
     fap_author="matthewkayne",

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.9.0"
+#define REPORT_APP_VERSION "1.10.0"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {
@@ -150,19 +150,6 @@ static const char* report_advice(CardType type) {
     }
 }
 
-static const char* report_risk_label(Severity severity) {
-    switch(severity) {
-    case SeverityHigh:
-        return "HIGH RISK";
-    case SeverityMedium:
-        return "MODERATE";
-    case SeverityLow:
-        return "LOW RISK";
-    default:
-        return "SECURE";
-    }
-}
-
 static void write_card_entry(File* f, size_t index, size_t total, const SessionEntry* entry) {
     char buf[64];
 
@@ -216,15 +203,16 @@ static void write_card_entry(File* f, size_t index, size_t total, const SessionE
         fw(f, buf);
     }
 
-    snprintf(buf, sizeof(buf), "  Risk:   %s\n", report_risk_label(entry->score.max_severity));
-    fw(f, buf);
-
     snprintf(
         buf,
         sizeof(buf),
-        "  Score:  %u/100  Confidence: %u%%\n",
+        "  Likelihood: %s  (%u/100, confidence %u%%)\n",
+        likelihood_label(entry->score.max_severity),
         entry->score.score,
         entry->score.confidence);
+    fw(f, buf);
+
+    snprintf(buf, sizeof(buf), "  Ease of exploit: %s\n", ease_of_exploit(&entry->obs));
     fw(f, buf);
 
     /* Rules triggered */
@@ -303,7 +291,7 @@ bool report_save_session(const ScanSession* session) {
     }
 
     if(open_ok) {
-        char buf[64];
+        char buf[96];
         SessionSummary sum = session_summarise(session);
 
         fw(file, "Access Audit Report\n");
@@ -340,7 +328,7 @@ bool report_save_session(const ScanSession* session) {
         snprintf(
             buf,
             sizeof(buf),
-            "High: %u  Medium: %u  Low: %u  Secure: %u\n",
+            "Likelihood  High: %u  Moderate: %u  Low: %u  Minimal: %u\n",
             (unsigned)sum.high,
             (unsigned)sum.medium,
             (unsigned)sum.low,
@@ -351,6 +339,14 @@ bool report_save_session(const ScanSession* session) {
                 buf, sizeof(buf), "Most common: %s\n", card_type_to_string(sum.most_common_type));
             fw(file, buf);
         }
+
+        fw(file, "\n");
+        fw(file, "Methodology: scores are a LIKELIHOOD-of-compromise rating (0-100) -- how\n");
+        fw(file, "easily the card technology can be cloned or its secret recovered. Aligned\n");
+        fw(file, "with the OWASP Risk Rating Methodology (Risk = Likelihood x Impact); this\n");
+        fw(file, "tool rates LIKELIHOOD only. IMPACT -- what the credential protects -- is\n");
+        fw(file, "assessed in engagement context.\n");
+        fw(file, "Ref: https://owasp.org/www-community/OWASP_Risk_Rating_Methodology\n");
 
         fw(file, "----------------------------------------\n\n");
 
@@ -383,12 +379,14 @@ bool report_save_session(const ScanSession* session) {
                 snprintf(
                     buf,
                     sizeof(buf),
-                    "ACTION REQUIRED: %u high-risk card(s) detected.\n",
+                    "ACTION REQUIRED: %u credential(s) with HIGH likelihood of compromise.\n",
                     (unsigned)sum.high);
                 fw(file, buf);
-                fw(file, "Replace or upgrade legacy credentials immediately.\n");
+                fw(file, "Replace or upgrade the legacy credentials; assess impact (what each\n");
+                fw(file, "credential protects) in engagement context.\n");
             } else {
-                fw(file, "REVIEW RECOMMENDED: moderate-risk card(s) detected.\n");
+                fw(file,
+                   "REVIEW RECOMMENDED: credential(s) with MODERATE likelihood of compromise.\n");
             }
             fw(file, "========================================\n");
         }

--- a/core/report.c
+++ b/core/report.c
@@ -346,7 +346,7 @@ bool report_save_session(const ScanSession* session) {
         fw(file, "with the OWASP Risk Rating Methodology (Risk = Likelihood x Impact); this\n");
         fw(file, "tool rates LIKELIHOOD only. IMPACT -- what the credential protects -- is\n");
         fw(file, "assessed in engagement context.\n");
-        fw(file, "Ref: https://owasp.org/www-community/OWASP_Risk_Rating_Methodology\n");
+        fw(file, "Ref: OWASP Risk Rating Methodology.\n");
 
         fw(file, "----------------------------------------\n\n");
 

--- a/core/scoring.c
+++ b/core/scoring.c
@@ -112,6 +112,66 @@ const char* severity_to_string(Severity severity) {
     }
 }
 
+const char* likelihood_label(Severity severity) {
+    switch(severity) {
+    case SeverityHigh:
+        return "HIGH";
+    case SeverityMedium:
+        return "MODERATE";
+    case SeverityLow:
+        return "LOW";
+    default:
+        return "MINIMAL";
+    }
+}
+
+const char* ease_of_exploit(const AccessObservation* obs) {
+    if(!obs) return "indeterminate";
+    /* A successful default-credential read means the card can be cloned outright. */
+    if(obs->default_keys_readable) return "trivial";
+    switch(obs->card_type) {
+    /* No cryptographic barrier — clone the identifier directly. */
+    case CardTypeEm4100Like:
+    case CardTypeHidProxLike:
+    case CardTypeHidGeneric:
+    case CardTypeIndala:
+    case CardTypeRfid125:
+    case CardTypeMifareUltralight:
+    case CardTypeNtag203:
+    case CardTypeNtag213:
+    case CardTypeNtag215:
+    case CardTypeNtag216:
+    case CardTypeNtagI2C:
+        return "trivial";
+    /* Broken or publicly-known crypto — active attack or known-key tooling required. */
+    case CardTypeMifareClassic:
+    case CardTypeMifareClassic1K:
+    case CardTypeMifareClassic4K:
+    case CardTypeMifareClassicMini:
+    case CardTypeMifarePlusSL1:
+    case CardTypeMifareUltralightC:
+    case CardTypeHidIclassLegacy:
+    case CardTypeHidIclassLegacy2k:
+    case CardTypeHidIclassLegacy16k:
+    case CardTypeHidIclassLegacy32k:
+    case CardTypeFeliCaLite:
+        return "moderate";
+    /* Modern cryptography with no public break. */
+    case CardTypeMifareDesfire:
+    case CardTypeMifareDesfireEV1:
+    case CardTypeMifareDesfireEV2:
+    case CardTypeMifareDesfireEV3:
+    case CardTypeMifareDesfireLight:
+    case CardTypeMifarePlus:
+    case CardTypeMifarePlusSL2:
+    case CardTypeMifarePlusSL3:
+    case CardTypeFelica:
+        return "hard";
+    default:
+        return "indeterminate";
+    }
+}
+
 const char* card_type_to_string(CardType type) {
     switch(type) {
     case CardTypeEm4100Like:

--- a/core/scoring.h
+++ b/core/scoring.h
@@ -19,3 +19,16 @@ typedef struct {
 AuditScore score_observation(const AccessObservation* obs);
 const char* severity_to_string(Severity severity);
 const char* card_type_to_string(CardType type);
+
+/* OWASP Risk Rating Methodology framing
+ * (https://owasp.org/www-community/OWASP_Risk_Rating_Methodology): the score is
+ * a LIKELIHOOD-of-compromise rating only — how easily the credential technology
+ * can be cloned or its secret recovered. IMPACT (what the credential protects)
+ * is assessed in engagement context, not by this tool. */
+
+/* Likelihood band for a severity: HIGH / MODERATE / LOW / MINIMAL. */
+const char* likelihood_label(Severity severity);
+
+/* OWASP "Ease of Exploit" likelihood factor for a credential:
+ * trivial / moderate / hard / indeterminate. */
+const char* ease_of_exploit(const AccessObservation* obs);

--- a/docs/card-types.md
+++ b/docs/card-types.md
@@ -4,6 +4,8 @@ Every `CardType` enum value, its risk rating under the default ruleset, where th
 
 Risk ratings assume `metadata_complete=true` and a UID is present. Incomplete metadata will add LOW RISK findings and reduce confidence.
 
+Ratings here express **likelihood of compromise** (OWASP *Ease of Exploit*), per the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology) — not the impact of a compromise, which is engagement-context. As a rule of thumb: HIGH RISK ≈ *trivial* to clone (no/broken crypto or static identifier), MODERATE ≈ *moderate* (active attack or known-key tooling), SECURE ≈ *hard* (modern crypto, no public break). See [scoring.md](scoring.md#ease-of-exploit-factor).
+
 ---
 
 ## 125 kHz RFID

--- a/docs/catalog-description.md
+++ b/docs/catalog-description.md
@@ -32,12 +32,14 @@ To build from source, install [uFBT](https://github.com/flipperdevices/flipperze
 
 **Reports**: sessions are saved as named .txt files on the SD card. The on-device viewer lets you scroll through past reports and delete them.
 
-## Score labels
+## Likelihood of compromise
 
-- **HIGH RISK** (35-100): legacy credential family (MIFARE Classic, EM4100, HID iCLASS Legacy, MIFARE Plus SL1) or static-replay pattern detected
-- **MODERATE** (20-34): risk indicators present; review recommended
+Scores are a likelihood-of-compromise rating aligned with the OWASP Risk Rating Methodology (Risk = Likelihood x Impact). The app rates likelihood only — how easily the credential can be cloned or its secret recovered. Impact (what the credential protects) is assessed in engagement context. Saved reports cite OWASP RRM: https://owasp.org/www-community/OWASP_Risk_Rating_Methodology
+
+- **HIGH RISK** (35-100): legacy credential family (MIFARE Classic, EM4100, HID iCLASS Legacy, MIFARE Plus SL1) or static-replay pattern — trivial to clone
+- **MODERATE** (20-34): broken or publicly-known crypto; active attack or known-key tooling needed
 - **LOW RISK** (10-19): minor concerns such as incomplete metadata
-- **SECURE** (0-9): modern cryptographic family with no major findings
+- **SECURE** (0-9): modern cryptographic family with no public break
 
 ## Card families detected
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,6 +2,8 @@
 
 Each rule maps to a named finding in saved reports. Rules are additive; multiple rules can fire on the same observation. The final score is clamped to 0-100.
 
+These rules are **likelihood signals** under the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology) (`Risk = Likelihood × Impact`): they rate how readily a credential can be compromised (its OWASP *Ease of Exploit*, *Awareness*, and *Detectability* factors), not the impact of a compromise. Impact — what the credential protects — is assessed by the operator in engagement context. See [scoring.md](scoring.md#methodology--owasp-risk-rating-alignment).
+
 ---
 
 ## High-risk rules

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -6,6 +6,8 @@ The score is a single integer in 0-100 that rates the **likelihood that a scanne
 
 This score is framed against the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology), where `Risk = Likelihood × Impact`.
 
+**Reference:** <https://owasp.org/www-community/OWASP_Risk_Rating_Methodology> (also cited in the header of every generated report).
+
 - **The tool rates LIKELIHOOD only.** Every rule below is a likelihood signal — the credential lacks crypto, uses a broken/known cipher, exposes only a static identifier, or was left on default keys. The rules encode OWASP likelihood factors such as **Ease of Exploit** (passive replay vs. active attack vs. infeasible), **Awareness** (publicly documented breaks), and **Detectability** (cloning leaves no trace).
 - **IMPACT is out of scope for the tool** — it depends on what the credential protects (a turnstile vs. a vault), which only the operator knows in engagement context. Final risk for a report should combine this likelihood with the operator's impact judgement.
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,6 +1,24 @@
 # Scoring
 
-The audit score is a single integer in 0-100 that summarises the risk exposure of a scanned credential. It is built from additive rule contributions minus any mitigations, then clamped to 0-100.
+The score is a single integer in 0-100 that rates the **likelihood that a scanned credential can be compromised** — how easily its technology can be cloned or its secret recovered. It is built from additive rule contributions minus any mitigations, then clamped to 0-100.
+
+## Methodology — OWASP Risk Rating alignment
+
+This score is framed against the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology), where `Risk = Likelihood × Impact`.
+
+- **The tool rates LIKELIHOOD only.** Every rule below is a likelihood signal — the credential lacks crypto, uses a broken/known cipher, exposes only a static identifier, or was left on default keys. The rules encode OWASP likelihood factors such as **Ease of Exploit** (passive replay vs. active attack vs. infeasible), **Awareness** (publicly documented breaks), and **Detectability** (cloning leaves no trace).
+- **IMPACT is out of scope for the tool** — it depends on what the credential protects (a turnstile vs. a vault), which only the operator knows in engagement context. Final risk for a report should combine this likelihood with the operator's impact judgement.
+
+Reports surface this as a `Likelihood: <HIGH/MODERATE/LOW/MINIMAL>` band plus an `Ease of exploit: <trivial/moderate/hard>` factor per card, and cite OWASP RRM in the header. The likelihood band maps directly from severity: HIGH→HIGH, MEDIUM→MODERATE, LOW→LOW, Info→MINIMAL.
+
+### Ease of exploit factor
+
+| Factor | Meaning | Credentials |
+|---|---|---|
+| **trivial** | no crypto barrier — clone the identifier directly, or default keys/password read | 125 kHz (EM4100/HID/Indala), NTAG/Ultralight, any card read with a default credential |
+| **moderate** | broken or publicly-known crypto — active attack or known-key tooling | MIFARE Classic, Plus SL1, Ultralight C, HID iCLASS Legacy, FeliCa Lite |
+| **hard** | modern cryptography with no public break | DESFire EV1/EV2/EV3/Light, Plus SL2/SL3, FeliCa Standard |
+| **indeterminate** | type not confirmed | unknown / generic ISO14443/15693 |
 
 ---
 


### PR DESCRIPTION
## Summary

Reframes the audit output around the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology) (`Risk = Likelihood × Impact`) and cites it in generated reports — **without changing the numeric scoring engine**. Only the framing, labels, and docs change.

The honest insight behind this: the tool can only measure **likelihood** of credential compromise (ease of cloning / secret recovery). **Impact** (what the credential protects — turnstile vs. vault) is engagement-context the device can't know. So the output now says exactly that.

## What changed

**Reports** (`report.c`):
- Per-card: `Risk: …` / `Score: …` → `Likelihood: <HIGH/MODERATE/LOW/MINIMAL> (N/100, confidence N%)` + `Ease of exploit: <trivial/moderate/hard>` (OWASP likelihood factor).
- Header: methodology note + OWASP RRM citation + explicit "likelihood only; impact assessed in context".
- Session advisory reworded in likelihood terms and prompts impact assessment.

**Engine** (`scoring.c/.h`): new `likelihood_label()` and `ease_of_exploit()` helpers. `score_observation()` and all rules are **unchanged** — same numbers, OWASP-aligned vocabulary.

**Docs**: `scoring.md` (new methodology + ease-of-exploit table), `rules.md`, `card-types.md`, README (Score interpretation), and the catalog description all explain and cite OWASP RRM.

## Sample report entry (after)

```
Card 1/1
  Type:   MIFARE Classic 1K
  UID:    (4-byte) DE AD BE EF
  Likelihood: HIGH  (75/100, confidence 90%)
  Ease of exploit: moderate
  Rules:  legacy_family, identifier_only, default_keys, crypto1_breakable
  Advice: Crypto1 is broken. Replace with DESFire EV2+ or Plus SL3.
```

## Verification
- `ufbt` build clean; clang-format + cppcheck pass.
- Bumped to **v1.10.0** (`fap_version=(1,10)`) — report-output change.

Not a wholesale switch to OWASP's 0–9 × 0–9 matrix: that needs an Impact value the tool can't know, and would discard the domain-tuned likelihood logic. This keeps the engine and speaks OWASP's language.
