### PR TITLE
Build against Unleashed SDK + guard LFRFID enum rename (#36)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,14 @@ jobs:
             sdk-channel: dev
             sdk-index-url: https://up.momentum-fw.dev/firmware/directory.json
 
+          - name: Unleashed release
+            sdk-channel: release
+            sdk-index-url: https://up.unleashedflip.com/directory.json
+
+          - name: Unleashed dev
+            sdk-channel: dev
+            sdk-index-url: https://up.unleashedflip.com/directory.json
+
     name: Build (${{ matrix.name }})
 
     steps:

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ The score is a **likelihood-of-compromise** rating aligned with the [OWASP Risk 
 
 ## Development
 
-- Platform: Flipper Zero (official firmware, Momentum)
+- Platform: Flipper Zero — compatible with official firmware, Momentum, and Unleashed
 - Language: C (uFBT / Flipper SDK)
-- CI: GitHub Actions, builds against official release, official dev, Momentum release, and Momentum dev SDKs on every push; clang-format and cppcheck lint on every push
+- CI: GitHub Actions, builds against official release, official dev, Momentum release, Momentum dev, Unleashed release, and Unleashed dev SDKs on every push; clang-format and cppcheck lint on every push
 
 ```
 core/

--- a/core/rfid_provider.c
+++ b/core/rfid_provider.c
@@ -14,8 +14,16 @@
 static CardType lfrfid_protocol_to_card_type(LFRFIDProtocol protocol) {
     switch(protocol) {
     case LFRFIDProtocolEM4100:
+/* Unleashed renamed the EM4100 bit-rate variants (EM410032 -> EM4100_32, etc.).
+ * FW_ORIGIN_Unleashed is defined by the Unleashed SDK; Official/Momentum keep
+ * the original names. Guarding here keeps full classification on all firmwares. */
+#ifdef FW_ORIGIN_Unleashed
+    case LFRFIDProtocolEM4100_32:
+    case LFRFIDProtocolEM4100_16:
+#else
     case LFRFIDProtocolEM410032:
     case LFRFIDProtocolEM410016:
+#endif
     case LFRFIDProtocolElectra:
         return CardTypeEm4100Like;
     case LFRFIDProtocolH10301:


### PR DESCRIPTION
Adds Unleashed to the CI build matrix and makes the app compile cleanly against it.

## What
- **CI**: `Unleashed release` + `Unleashed dev` added to `build.yml` (index `https://up.unleashedflip.com/directory.json`), alongside Official and Momentum — 6 build variants total.
- **Portability fix**: Unleashed renamed the EM4100 bit-rate variant enums (`LFRFIDProtocolEM410032` → `EM4100_32`, `…16`), which broke the build there. Guarded with `#ifdef FW_ORIGIN_Unleashed` (defined by the Unleashed SDK; Official/Momentum define their own `FW_ORIGIN_*`), so **full EM4100 classification is preserved on every firmware**.
- **Docs**: README Development section now lists Unleashed as supported.

## Why a code change was needed
#36 looked like a pure CI tweak, but the app didn't actually compile on Unleashed — verifying locally caught it. The `#else` branch keeps the exact original enum names, so **Official/Momentum builds are behavior-identical** (no version bump, no release needed; the released catalog FAP is the Official build).

## Verified locally
Builds clean on **Unleashed release**, **Unleashed dev**, and **Official release**; clang-format + cppcheck pass. CI will confirm all 6 variants.

Closes #36