### PR TITLE
Add catalog-safe changelog (fixes catalog publishing)

### DIFF
--- a/docs/catalog-changelog.md
+++ b/docs/catalog-changelog.md
@@ -1,0 +1,11 @@
+## 1.10.0
+Reports now present the score as a **likelihood-of-compromise** rating aligned with the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology). Each card shows a Likelihood band (HIGH/MODERATE/LOW/MINIMAL) and an Ease-of-exploit factor. The tool rates likelihood only; impact (what the credential protects) is assessed in engagement context.
+
+## 1.9.0
+Expanded the MIFARE Classic default-key check to 8 well-known public keys, and the default-key finding is now shown on the result screen, not just in the saved report.
+
+## 1.8.x
+MIFARE Classic scan reliability fix; the app version is shown on the scan screen.
+
+## Earlier
+FeliCa sub-type detection, HID iCLASS Legacy support, 125 kHz RFID support, on-device report viewer, named sessions, lint/CI hardening, and the initial NFC classification with 0-100 risk scoring.


### PR DESCRIPTION
Adds `docs/catalog-changelog.md` — a catalog-safe changelog for the Apps Catalog manifest.

**Why:** the app has never appeared on lab.flipper.net. Root cause (found via the catalog's own `bundle.py`): (1) the catalog entry is named `manifest.yaml` but the backend requires `manifest.yml`; (2) the catalog markdown filter allows only H1–H2 / bold / italic / lists / links — `CHANGELOG.md`'s H3 headers, `[x.y.z]:` reference-defs, and backticks all fail it.

This PR adds a dedicated catalog changelog (like `catalog-description.md` is separate from the README); `CHANGELOG.md` is untouched for GitHub. The matching catalog-repo PR renames the manifest and points `changelog` at this file. Validated end-to-end: the catalog bundler now builds + publishes successfully.

Docs-only; no version change.