### PR TITLE
Sync source manifest.yml with catalog + fix automation path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,8 @@ jobs:
           git fetch upstream main
           BRANCH="matthewkayne/access_audit_${TAG#v}"
           git checkout -B "$BRANCH" upstream/main
-          # The catalog entry lives here and uses .yaml (not .yml) — see CLAUDE.md §6.
-          MANIFEST="applications/Tools/access_audit/manifest.yaml"
+          # The catalog entry lives here (must be manifest.yml — see CLAUDE.md §6).
+          MANIFEST="applications/Tools/access_audit/manifest.yml"
           sed -i -E "s/(commit_sha:[[:space:]]*).*/\1${RELEASE_SHA}/" "$MANIFEST"
           if git diff --quiet "$MANIFEST"; then
             echo "catalog commit_sha already current — nothing to submit"

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,10 +2,10 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/matthewkayne/flipper-access-audit.git
-    commit_sha: aa4aea8a870906f3c8b01cc98b7f111ea63d3105
+    commit_sha: 3336f4308249f662d570e921390215066aa0859d
 author: Matthew Kayne
-description: "@README.md"
-changelog: "@./CHANGELOG.md"
+description: "@docs/catalog-description.md"
+changelog: "@docs/catalog-changelog.md"
 screenshots:
   - screenshots/ss0.png
   - screenshots/ss1.png


### PR DESCRIPTION
Follow-up to the catalog publishing fix (catalog PR flipperdevices/flipper-application-catalog#1095).

- **manifest.yml** now mirrors the corrected catalog entry (description -> docs/catalog-description.md, changelog -> docs/catalog-changelog.md, commit_sha bumped) — resolves the source/catalog divergence.
- **release.yml** catalog-pr automation now targets manifest.yml (the catalog file was renamed from .yaml); the old path would have silently no-op'd.

No app/version change.