### PR TITLE
Fix MIFARE Plus SL2 + FeliCa Standard scoring (v1.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented here.
 
+## [1.10.1]: Scoring fixes — MIFARE Plus SL2 and FeliCa Standard
+
+### Fixed
+- **MIFARE Plus SL2 now scores MODERATE (was SECURE)**: SL2 is the weak transitional mode (AES authentication but Classic frame structure, downgrade-prone), so it is no longer treated as having protected application memory. Only SL3 (full AES + ISO14443-4) is. This matches the documented behaviour in `docs/card-types.md`
+- **FeliCa Standard now scores SECURE (was MODERATE)**: standard FeliCa has proprietary mutual authentication protecting its blocks, so it is treated as having protected memory (like DESFire); FeliCa Lite (no mutual auth) remains HIGH RISK. Matches `docs/card-types.md`
+- `ease_of_exploit` for MIFARE Plus SL2 moved from `hard` to `moderate` to match its MODERATE likelihood (downgrade/UID-replay, not a crypto break)
+- Corrected the `docs/scoring.md` "Unknown card / scan failure" worked example: a failed/incomplete read scores 20/100 but is labelled **LOW RISK** (both findings are LOW severity), not MODERATE — the label follows the highest finding severity, not the score band
+
 ## [1.10.0]: OWASP Risk Rating Methodology framing
 
 ### Changed

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.10.0"
+#define APP_VERSION "1.10.1"
 
 #include "access_audit.h"
 #include "core/observation.h"

--- a/core/observation_provider.c
+++ b/core/observation_provider.c
@@ -488,10 +488,12 @@ static NfcCommand mf_plus_poller_cb(NfcGenericEvent event, void* context) {
             p->pending.tech = TechTypeNfc13Mhz;
             p->pending.card_type = mf_plus_sl_to_card_type(plus_data->security_level);
             p->pending.metadata_complete = true;
-            /* SL2/SL3 have AES-protected sectors; SL1 is Classic-compat */
-            p->pending.user_memory_present =
-                (plus_data->security_level == MfPlusSecurityLevel2 ||
-                 plus_data->security_level == MfPlusSecurityLevel3);
+            /* SL3 = full AES + ISO14443-4 with protected application memory.
+             * SL2 is the weak transitional mode (AES auth but Classic frame
+             * structure, downgrade-prone), so it is NOT treated as having
+             * protected memory — it scores MODERATE, not SECURE (see
+             * docs/card-types.md). SL1 is Classic-compatible (no AES in use). */
+            p->pending.user_memory_present = (plus_data->security_level == MfPlusSecurityLevel3);
 
             if(uid && uid_len > 0) {
                 p->pending.uid_present = true;
@@ -744,11 +746,14 @@ static NfcCommand felica_poller_cb(NfcGenericEvent event, void* context) {
         p->pending.tech = TechTypeNfc13Mhz;
         p->pending.metadata_complete = (fc_event->type == FelicaPollerEventTypeReady);
 
-        /* Classify by workflow type */
+        /* Classify by workflow type. Standard FeliCa has proprietary mutual
+         * authentication protecting its blocks (scores SECURE); Lite has no
+         * mutual auth — it is a UID-only credential (scores HIGH RISK). */
         if(fc_data->workflow_type == FelicaLite) {
             p->pending.card_type = CardTypeFeliCaLite;
         } else {
             p->pending.card_type = CardTypeFelica;
+            p->pending.user_memory_present = true;
         }
 
         if(uid && uid_len > 0) {

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.10.0"
+#define REPORT_APP_VERSION "1.10.1"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {

--- a/core/scoring.c
+++ b/core/scoring.c
@@ -149,6 +149,7 @@ const char* ease_of_exploit(const AccessObservation* obs) {
     case CardTypeMifareClassic4K:
     case CardTypeMifareClassicMini:
     case CardTypeMifarePlusSL1:
+    case CardTypeMifarePlusSL2:
     case CardTypeMifareUltralightC:
     case CardTypeHidIclassLegacy:
     case CardTypeHidIclassLegacy2k:
@@ -163,7 +164,6 @@ const char* ease_of_exploit(const AccessObservation* obs) {
     case CardTypeMifareDesfireEV3:
     case CardTypeMifareDesfireLight:
     case CardTypeMifarePlus:
-    case CardTypeMifarePlusSL2:
     case CardTypeMifarePlusSL3:
     case CardTypeFelica:
         return "hard";

--- a/docs/catalog-changelog.md
+++ b/docs/catalog-changelog.md
@@ -1,3 +1,6 @@
+## 1.10.1
+Scoring corrections: MIFARE Plus SL2 now scores MODERATE (it is the weak transitional mode — AES auth but Classic frames), and FeliCa Standard now scores SECURE (it has proprietary mutual authentication). FeliCa Lite remains HIGH RISK.
+
 ## 1.10.0
 Reports now present the score as a **likelihood-of-compromise** rating aligned with the [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology). Each card shows a Likelihood band (HIGH/MODERATE/LOW/MINIMAL) and an Ease-of-exploit factor. The tool rates likelihood only; impact (what the credential protects) is assessed in engagement context.
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -204,10 +204,12 @@ If both `modern_crypto` and `legacy_family` fire simultaneously (which cannot ha
 | `incomplete_evidence` fires | +10, -20% confidence |
 | `no_uid` fires | +10, -15% confidence |
 | Score | 20 |
-| Max severity | MEDIUM |
+| Max severity | LOW |
 | Confidence | 55% |
 
-**Result: MODERATE · 20/100 · 55% confidence**
+**Result: LOW RISK · 20/100 · 55% confidence**
+
+> Note the **label follows the highest-severity finding (`max_severity`), not the score band**. Here both findings are LOW severity, so the label is LOW RISK even though the score (20) sits in the MODERATE band — a failed/incomplete read shouldn't read as a moderate-risk *credential*. The score-range column in the threshold tables is a typical-case guide; the authoritative label is the dominant finding's severity. (A card whose `card_type` is genuinely `Unknown` short-circuits to 0/100 at 0% confidence.)
 
 ---
 


### PR DESCRIPTION
Scoring audit (compiled rules.c/scoring.c natively and computed every card type). Two cards didn't match the documented spec in docs/card-types.md:

| Card | Was | Now | Spec |
|---|---|---|---|
| MIFARE Plus SL2 | SECURE (0) | **MODERATE (15)** | MODERATE |
| FeliCa Standard | MODERATE (15) | **SECURE (0)** | SECURE |

Root cause: the `user_memory_present` flag (which gates `identifier_only_pattern`). It was set for SL2 (shouldn't be — SL2 is the weak transitional mode) and not for FeliCa Standard (should be — it has mutual auth). Fixed both; SL3/DESFire/Lite/everything else unchanged. Also moved SL2's `ease_of_exploit` hard→moderate, and corrected the scoring.md 'scan failure' example (20/100 is LOW RISK, not MODERATE — label follows severity, not score band).

Patch release v1.10.1. Build + clang-format + cppcheck pass.