### PR TITLE
docs: SL2 ease-of-exploit moderate (match v1.10.1)

### DIFF
--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -18,8 +18,8 @@ Reports surface this as a `Likelihood: <HIGH/MODERATE/LOW/MINIMAL>` band plus an
 | Factor | Meaning | Credentials |
 |---|---|---|
 | **trivial** | no crypto barrier — clone the identifier directly, or default keys/password read | 125 kHz (EM4100/HID/Indala), NTAG/Ultralight, any card read with a default credential |
-| **moderate** | broken or publicly-known crypto — active attack or known-key tooling | MIFARE Classic, Plus SL1, Ultralight C, HID iCLASS Legacy, FeliCa Lite |
-| **hard** | modern cryptography with no public break | DESFire EV1/EV2/EV3/Light, Plus SL2/SL3, FeliCa Standard |
+| **moderate** | broken or publicly-known crypto — active attack or known-key tooling | MIFARE Classic, Plus SL1, Plus SL2, Ultralight C, HID iCLASS Legacy, FeliCa Lite |
+| **hard** | modern cryptography with no public break | DESFire EV1/EV2/EV3/Light, Plus SL3, FeliCa Standard |
 | **indeterminate** | type not confirmed | unknown / generic ISO14443/15693 |
 
 ---


### PR DESCRIPTION
Follow-up to #63: `ease_of_exploit` for MIFARE Plus SL2 was moved hard→moderate in code; this updates the scoring.md ease-of-exploit table to match. Docs-only.