### PR TITLE
Fix scan-screen spacing (v1.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [1.10.2]: Scan-screen spacing fix
+
+### Fixed
+- **Scan-screen lines re-spaced (~10px)** so the version line no longer collides with the title divider above or the "Tap card to reader" prompt below. The version, scan prompt, "Scanning…" status, mode hint, and controls row are now evenly spaced
+
 ## [1.10.1]: Scoring fixes — MIFARE Plus SL2 and FeliCa Standard
 
 ### Fixed

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.10.1"
+#define APP_VERSION "1.10.2"
 
 #include "access_audit.h"
 #include "core/observation.h"
@@ -157,7 +157,7 @@ static void access_audit_draw_callback(Canvas* canvas, void* context) {
         canvas_draw_line(canvas, 0, 13, 127, 13);
 
         canvas_set_font(canvas, FontSecondary);
-        canvas_draw_str(canvas, 2, 20, "v" APP_VERSION);
+        canvas_draw_str(canvas, 2, 22, "v" APP_VERSION);
         canvas_draw_str_aligned(
             canvas,
             126,
@@ -170,17 +170,17 @@ static void access_audit_draw_callback(Canvas* canvas, void* context) {
         if(app->session.count > 0) {
             char cbuf[16];
             snprintf(cbuf, sizeof(cbuf), "[%u]", (unsigned)app->session.count);
-            canvas_draw_str_aligned(canvas, 126, 24, AlignRight, AlignBottom, cbuf);
+            canvas_draw_str_aligned(canvas, 126, 22, AlignRight, AlignBottom, cbuf);
         }
         canvas_draw_str(
             canvas,
             2,
-            26,
+            32,
             app->scan_mode == ScanModeNfc    ? "Tap card to reader..." :
             app->scan_mode == ScanModeIclass ? "Tap iCLASS card..." :
                                                "Hold card to reader...");
-        canvas_draw_str(canvas, 2, 38, "Scanning...");
-        canvas_draw_str(canvas, 2, 50, "< > NFC/RFID/iCLASS");
+        canvas_draw_str(canvas, 2, 42, "Scanning...");
+        canvas_draw_str(canvas, 2, 52, "< > NFC/RFID/iCLASS");
         canvas_draw_str(canvas, 2, 62, "Up:reports  Back:exit");
         return;
     }

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.10.1"
+#define REPORT_APP_VERSION "1.10.2"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {

--- a/docs/catalog-changelog.md
+++ b/docs/catalog-changelog.md
@@ -1,3 +1,6 @@
+## 1.10.2
+Scan-screen layout fix: the version line and prompts are evenly spaced (no longer squashed under the title divider).
+
 ## 1.10.1
 Scoring corrections: MIFARE Plus SL2 now scores MODERATE (it is the weak transitional mode — AES auth but Classic frames), and FeliCa Standard now scores SECURE (it has proprietary mutual authentication). FeliCa Lite remains HIGH RISK.
 


### PR DESCRIPTION
The version line was squashed against the title divider and the scan prompt. Re-spaced the scan screen to even ~10px line spacing. Patch release v1.10.2. Verified on-device (Momentum).