### PR TITLE
chore: mirror manifest.yml commit_sha to catalog

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/matthewkayne/flipper-access-audit.git
-    commit_sha: a7dff1d885d019fde0c490de7b801b93d99b2117
+    commit_sha: 7d881cb54547dfd0fe1ba4fa01f4c823cb086e13
 author: Matthew Kayne
 description: "@docs/catalog-description.md"
 changelog: "@docs/catalog-changelog.md"


### PR DESCRIPTION
Keeps source manifest.yml record == catalog PR #1095 commit_sha (7d881cb). Record only.