### PR TITLE
Detect HID Seos via ISO14443-4A AID SELECT (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [1.11.0]: HID Seos detection
+
+### Added
+- **HID Seos detection**: ISO14443-4A smart cards are now routed to the `iso14443_4a` poller, which performs an ISO-7816 `SELECT` of the HID Seos applet AID. A `0x9000` response classifies the card as **HID Seos** (previously it fell through to generic `ISO 14443-4A`). Seos is a modern AES secure element, so it scores **SECURE** with advice to disable any legacy/Prox fallback at the reader. Passive identification only — reading the PACS (facility code / card number) still requires a HID SAM (#53). Non-Seos ISO14443-4A cards are unaffected (still classified as `ISO 14443-A`)
+
 ## [1.10.2]: Scan-screen spacing fix
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Tap a card, get an instant risk score and plain-English advice. Save a named ses
 
 ## Features
 
-- **Deep card classification**: MIFARE Classic 1K/4K/Mini, DESFire EV1/EV2/EV3/Light, MIFARE Plus SL1/SL2/SL3, Ultralight C, NTAG203/213/215/216, NTAG I2C, ISO14443-A/B, ISO15693, FeliCa (Standard/Lite), SLIX, ST25TB; 125 kHz RFID: EM4100, HID H10301, HID Generic, Indala; HID iCLASS (Legacy) 2k/16k/32k
+- **Deep card classification**: MIFARE Classic 1K/4K/Mini, DESFire EV1/EV2/EV3/Light, MIFARE Plus SL1/SL2/SL3, Ultralight C, NTAG203/213/215/216, NTAG I2C, ISO14443-A/B, ISO15693, FeliCa (Standard/Lite), SLIX, ST25TB; 125 kHz RFID: EM4100, HID H10301, HID Generic, Indala; HID iCLASS (Legacy) 2k/16k/32k; **HID Seos** (via AID select)
 - **Instant risk score**: 0-100 score with HIGH RISK / MODERATE / LOW RISK / SECURE label
 - **Per-card advice**: plain-English recommendation written to every report entry
 - **Multi-scan sessions**: scan up to 20 cards per session; live `[N]` counter visible on both scan and result screens
@@ -94,6 +94,7 @@ The score is a **likelihood-of-compromise** rating aligned with the [OWASP Risk 
 | MIFARE Plus | SL1 · SL2 · SL3 (via security level response) |
 | MIFARE Ultralight / NTAG | Ultralight C · NTAG203/213/215/216 · NTAG I2C |
 | HID iCLASS | Legacy 2k · Legacy 16k · Legacy 32k (via ACTALL/IDENTIFY/READ block 1) |
+| HID Seos | Detected on ISO14443-4A via Seos AID `SELECT` (NFC mode) |
 | 125 kHz RFID | EM4100 · HID H10301 · HID Generic · Indala · generic 125 kHz |
 
 ---

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.10.2"
+#define APP_VERSION "1.11.0"
 
 #include "access_audit.h"
 #include "core/observation.h"

--- a/application.fam
+++ b/application.fam
@@ -6,10 +6,10 @@ App(
     sources=["*.c"],
     requires=["gui", "nfc", "storage"],
     stack_size=2 * 1024,
-    fap_version=(1, 10),
+    fap_version=(1, 11),
     fap_icon="icon.png",
     fap_category="Tools",
     fap_author="matthewkayne",
-    fap_description="Audit NFC, RFID, and HID iCLASS access-control cards. Detects DESFire EV1/EV2/EV3, MIFARE Classic/Plus SL1-SL3, NTAG, EM4100, HID iCLASS Legacy, and more. Instant risk score with per-card advice.",
+    fap_description="Audit NFC, RFID, and HID iCLASS access-control cards. Detects DESFire EV1/EV2/EV3, MIFARE Classic/Plus SL1-SL3, NTAG, EM4100, HID iCLASS Legacy, HID Seos, and more. Instant risk score with per-card advice.",
     fap_weburl="https://github.com/matthewkayne/flipper-access-audit",
 )

--- a/core/observation.h
+++ b/core/observation.h
@@ -50,6 +50,7 @@ typedef enum {
     CardTypeHidIclassLegacy2k, /* iCLASS DES/3DES, 2 kilobit memory (most common) */
     CardTypeHidIclassLegacy16k, /* iCLASS DES/3DES, 16 kilobit memory */
     CardTypeHidIclassLegacy32k, /* iCLASS DES/3DES, 32 kilobit memory */
+    CardTypeSeos, /* HID Seos — ISO14443-4A AES secure element; detected via Seos AID SELECT */
     CardTypeFelica, /* generic fallback — workflow type unknown */
     CardTypeFeliCaLite, /* FeliCa Lite — no mutual auth, used in transit/building */
     CardTypeSlix,

--- a/core/observation_provider.c
+++ b/core/observation_provider.c
@@ -5,6 +5,10 @@
 #include <nfc/protocols/nfc_protocol.h>
 #include <nfc/protocols/iso14443_3a/iso14443_3a.h>
 #include <nfc/protocols/iso14443_3a/iso14443_3a_poller.h>
+#include <nfc/protocols/iso14443_4a/iso14443_4a.h>
+#include <nfc/protocols/iso14443_4a/iso14443_4a_poller.h>
+#include <toolbox/bit_buffer.h>
+#include <string.h>
 #include <nfc/protocols/mf_classic/mf_classic.h>
 #include <nfc/protocols/mf_classic/mf_classic_poller.h>
 #include <nfc/protocols/mf_ultralight/mf_ultralight.h>
@@ -164,6 +168,12 @@ static NfcProtocol uid_transport(const NfcProtocol* protos, size_t count) {
             return NfcProtocolMfUltralight;
         }
     }
+    /* Prefer ISO14443-4a for ISO-7816 smart cards (e.g. HID Seos) so we can
+     * send APDUs to identify the applet. Non-Seos 4a cards fall back to the
+     * generic ISO14443-A classification. */
+    for(size_t i = 0; i < count; i++) {
+        if(protos[i] == NfcProtocolIso14443_4a) return NfcProtocolIso14443_4a;
+    }
     for(size_t i = 0; i < count; i++) {
         if(protos[i] == NfcProtocolIso14443_3a ||
            nfc_protocol_has_parent(protos[i], NfcProtocolIso14443_3a)) {
@@ -307,6 +317,102 @@ static void scanner_callback(NfcScannerEvent event, void* context) {
  * while the card is definitely present, then stop.
  * -------------------------------------------------------------------------
  */
+
+/* -------------------------------------------------------------------------
+ * ISO14443-4a poller callback  (runs on NFC worker thread)
+ *
+ * For ISO-7816 smart cards (Seos and other 4-layer cards) we activate the
+ * ISO14443-4a layer and attempt an APDU SELECT of the HID Seos application.
+ * A 0x9000 response confirms HID Seos. This is a passive identify only — it
+ * does NOT read PACS (facility code / card number), which requires a HID SAM
+ * (see issue #53). Non-Seos 4a cards classify as generic ISO14443-A.
+ * -------------------------------------------------------------------------
+ */
+
+/* HID Seos applet AID. */
+static const uint8_t SEOS_AID[] = {0xA0, 0x00, 0x00, 0x04, 0x40, 0x00, 0x01, 0x01, 0x00, 0x01};
+
+static bool iso14443_4a_card_is_seos(Iso14443_4aPoller* poller) {
+    /* ISO-7816 SELECT by name (P1=0x04): 00 A4 04 00 <Lc> <AID> 00 */
+    uint8_t apdu[5 + sizeof(SEOS_AID) + 1];
+    size_t n = 0;
+    apdu[n++] = 0x00; /* CLA */
+    apdu[n++] = 0xA4; /* INS: SELECT */
+    apdu[n++] = 0x04; /* P1: select by name (AID) */
+    apdu[n++] = 0x00; /* P2 */
+    apdu[n++] = (uint8_t)sizeof(SEOS_AID); /* Lc */
+    memcpy(&apdu[n], SEOS_AID, sizeof(SEOS_AID));
+    n += sizeof(SEOS_AID);
+    apdu[n++] = 0x00; /* Le */
+
+    BitBuffer* tx = bit_buffer_alloc(sizeof(apdu));
+    BitBuffer* rx = bit_buffer_alloc(64);
+    bit_buffer_append_bytes(tx, apdu, n);
+
+    bool is_seos = false;
+    if(iso14443_4a_poller_send_block(poller, tx, rx) == Iso14443_4aErrorNone) {
+        size_t len = bit_buffer_get_size_bytes(rx);
+        /* Success = trailing status word 0x9000. */
+        if(len >= 2 && bit_buffer_get_byte(rx, len - 2) == 0x90 &&
+           bit_buffer_get_byte(rx, len - 1) == 0x00) {
+            is_seos = true;
+        }
+    }
+
+    bit_buffer_free(tx);
+    bit_buffer_free(rx);
+    return is_seos;
+}
+
+static NfcCommand iso14443_4a_poller_cb(NfcGenericEvent event, void* context) {
+    ObservationProvider* p = context;
+    const Iso14443_4aPollerEvent* ev = (const Iso14443_4aPollerEvent*)event.event_data;
+
+    if(ev->type != Iso14443_4aPollerEventTypeReady) {
+        furi_mutex_acquire(p->mutex, FuriWaitForever);
+        p->state = ProviderStateReadFailed;
+        furi_mutex_release(p->mutex);
+        return NfcCommandStop;
+    }
+
+    /* APDU exchange runs on the worker thread before we touch shared state. */
+    bool seos = iso14443_4a_card_is_seos((Iso14443_4aPoller*)event.instance);
+
+    furi_mutex_acquire(p->mutex, FuriWaitForever);
+
+    const Iso14443_4aData* data = (const Iso14443_4aData*)nfc_poller_get_data(p->poller);
+    if(data) {
+        size_t uid_len = 0;
+        const uint8_t* uid = iso14443_3a_get_uid(data->iso14443_3a_data, &uid_len);
+
+        p->pending = (AccessObservation){0};
+        p->pending.tech = TechTypeNfc13Mhz;
+        p->pending.metadata_complete = true;
+        if(seos) {
+            p->pending.card_type = CardTypeSeos;
+            /* Seos is an AES secure element — credential is in protected memory. */
+            p->pending.user_memory_present = true;
+        } else {
+            p->pending.card_type = CardTypeIso14443A;
+        }
+
+        if(uid && uid_len > 0) {
+            p->pending.uid_present = true;
+            p->pending.uid_len = uid_len <= sizeof(p->pending.uid) ? uid_len :
+                                                                     sizeof(p->pending.uid);
+            for(size_t i = 0; i < p->pending.uid_len; i++) {
+                p->pending.uid[i] = uid[i];
+            }
+        }
+
+        p->state = ProviderStateDone;
+    } else {
+        p->state = ProviderStateReadFailed;
+    }
+
+    furi_mutex_release(p->mutex);
+    return NfcCommandStop;
+}
 
 static NfcCommand iso14443_3a_poller_cb(NfcGenericEvent event, void* context) {
     ObservationProvider* p = context;
@@ -804,6 +910,8 @@ static NfcGenericCallback callback_for_protocol(NfcProtocol protocol) {
         return mf_classic_poller_cb;
     case NfcProtocolMfUltralight:
         return mf_ultralight_poller_cb;
+    case NfcProtocolIso14443_4a:
+        return iso14443_4a_poller_cb;
     case NfcProtocolIso14443_3a:
         return iso14443_3a_poller_cb;
     case NfcProtocolIso15693_3:

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.10.2"
+#define REPORT_APP_VERSION "1.11.0"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {

--- a/core/report.c
+++ b/core/report.c
@@ -141,6 +141,8 @@ static const char* report_advice(CardType type) {
     case CardTypeHidIclassLegacy16k:
     case CardTypeHidIclassLegacy32k:
         return "iCLASS DES/3DES master key is publicly known. Upgrade to iCLASS SE/Seos.";
+    case CardTypeSeos:
+        return "HID Seos (AES secure element). Strong; ensure the reader has legacy/Prox fallback disabled.";
     case CardTypeFelica:
         return "Verify FeliCa application crypto is properly configured.";
     case CardTypeFeliCaLite:

--- a/core/rules.c
+++ b/core/rules.c
@@ -73,6 +73,8 @@ bool rule_modern_crypto(const AccessObservation* obs) {
     case CardTypeMifarePlusSL3:
     /* FeliCa Standard uses proprietary crypto — Lite does not */
     case CardTypeFelica:
+    /* HID Seos — AES secure element on ISO14443-4A */
+    case CardTypeSeos:
         return true;
     default:
         return false;

--- a/core/scoring.c
+++ b/core/scoring.c
@@ -166,6 +166,7 @@ const char* ease_of_exploit(const AccessObservation* obs) {
     case CardTypeMifarePlus:
     case CardTypeMifarePlusSL3:
     case CardTypeFelica:
+    case CardTypeSeos:
         return "hard";
     default:
         return "indeterminate";
@@ -240,6 +241,8 @@ const char* card_type_to_string(CardType type) {
         return "HID iCLASS 16k (Legacy)";
     case CardTypeHidIclassLegacy32k:
         return "HID iCLASS 32k (Legacy)";
+    case CardTypeSeos:
+        return "HID Seos";
     case CardTypeFelica:
         return "FeliCa";
     case CardTypeFeliCaLite:

--- a/docs/card-types.md
+++ b/docs/card-types.md
@@ -92,7 +92,7 @@ These types appear when the poller cannot determine a more specific sub-type. Tr
 
 ---
 
-## HID iCLASS family
+## HID iCLASS / Seos family
 
 | Card Type | Risk | Crypto | Recommendation |
 |---|---|---|---|
@@ -101,8 +101,11 @@ These types appear when the poller cannot determine a more specific sub-type. Tr
 | `CardTypeHidIclassLegacy2k` | **HIGH RISK** | DES/3DES, 2 kilobit (standard) | Upgrade to iCLASS SE or Seos |
 | `CardTypeHidIclassLegacy16k` | **HIGH RISK** | DES/3DES, 16 kilobit | Upgrade to iCLASS SE or Seos |
 | `CardTypeHidIclassLegacy32k` | **HIGH RISK** | DES/3DES, 32 kilobit | Upgrade to iCLASS SE or Seos |
+| `CardTypeSeos` | SECURE | AES secure element (ISO14443-4A) | Modern; ensure reader has legacy/Prox fallback disabled |
 
 The iCLASS standard DES/3DES master key was publicly disclosed. Attacks against iCLASS Legacy are well-documented and practical. HID's own recommendation is to migrate to iCLASS SE (AES) or Seos.
+
+**Radio note:** iCLASS (Legacy and SE) is read over **ISO 15693** — use the app's **iCLASS scan mode**. **Seos** is an ISO 14443-4A secure element, so it scans in **NFC mode** (not iCLASS mode) and is identified by an AID `SELECT`. A pure-Seos credential will only appear in NFC mode; a dual iCLASS+Seos card appears in both. Reading the actual PACS from Seos/SE requires a HID SAM (see project issue #53).
 
 ---
 

--- a/docs/catalog-changelog.md
+++ b/docs/catalog-changelog.md
@@ -1,3 +1,6 @@
+## 1.11.0
+HID Seos detection: Seos cards (ISO14443-4A) are now identified via an AID SELECT and scored SECURE, instead of showing as a generic ISO 14443-4A card. Passive identify only — reading the PACS still needs a HID SAM.
+
 ## 1.10.2
 Scan-screen layout fix: the version line and prompts are evenly spaced (no longer squashed under the title divider).
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -116,6 +116,7 @@ Matches:
 - MIFARE Plus SL2, AES crypto active (Classic-format frames)
 - MIFARE Plus SL3, AES crypto + ISO14443-4 protocol
 - FeliCa Standard, proprietary crypto (FeliCa Lite is excluded, no mutual auth)
+- HID Seos, AES secure element on ISO14443-4A (identified by Seos AID `SELECT`)
 
 **Score contribution:** -20
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -19,7 +19,7 @@ Reports surface this as a `Likelihood: <HIGH/MODERATE/LOW/MINIMAL>` band plus an
 |---|---|---|
 | **trivial** | no crypto barrier — clone the identifier directly, or default keys/password read | 125 kHz (EM4100/HID/Indala), NTAG/Ultralight, any card read with a default credential |
 | **moderate** | broken or publicly-known crypto — active attack or known-key tooling | MIFARE Classic, Plus SL1, Plus SL2, Ultralight C, HID iCLASS Legacy, FeliCa Lite |
-| **hard** | modern cryptography with no public break | DESFire EV1/EV2/EV3/Light, Plus SL3, FeliCa Standard |
+| **hard** | modern cryptography with no public break | DESFire EV1/EV2/EV3/Light, Plus SL3, FeliCa Standard, HID Seos |
 | **indeterminate** | type not confirmed | unknown / generic ISO14443/15693 |
 
 ---


### PR DESCRIPTION
Adds passive HID Seos detection. Routes ISO14443-4A cards to the iso14443_4a poller and SELECTs the Seos AID (`A0 00 00 04 40 00 01 01 00 01`); `0x9000` → `CardTypeSeos` (SECURE, modern AES secure element). Non-Seos 4a cards classify as generic ISO14443-A as before.

Passive identify only — PACS read needs the SAM (#53). Addresses the Seos half of #22 (iCLASS SE detection still pending).

**Needs on-device verification** against a real Seos card before merge. Build + clang-format + cppcheck pass; Seos scores SECURE in the native scoring harness.