### PR TITLE
chore: manifest.yml commit_sha -> v1.11.0

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/matthewkayne/flipper-access-audit.git
-    commit_sha: 7d881cb54547dfd0fe1ba4fa01f4c823cb086e13
+    commit_sha: 83de0c7faa0500a11b7e2083961773d9eb7504f0
 author: Matthew Kayne
 description: "@docs/catalog-description.md"
 changelog: "@docs/catalog-changelog.md"


### PR DESCRIPTION
Keeps the source manifest.yml record current with v1.11.0. Record only.