### PR TITLE
Clarify iCLASS scan mode (v1.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [1.11.1]: Clarify iCLASS scan mode
+
+### Changed
+- **iCLASS scan-mode prompt clarified**: the prompt now reads `Tap iCLASS SE/Legacy...` with a `Seos? use NFC mode` hint below it. iCLASS Legacy/SE are on ISO 15693 (iCLASS mode); Seos is ISO 14443-4A (NFC mode) — the shared "iCLASS" branding made the mode ambiguous
+
 ## [1.11.0]: HID Seos detection
 
 ### Added

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.11.0"
+#define APP_VERSION "1.11.1"
 
 #include "access_audit.h"
 #include "core/observation.h"
@@ -177,9 +177,11 @@ static void access_audit_draw_callback(Canvas* canvas, void* context) {
             2,
             32,
             app->scan_mode == ScanModeNfc    ? "Tap card to reader..." :
-            app->scan_mode == ScanModeIclass ? "Tap iCLASS card..." :
+            app->scan_mode == ScanModeIclass ? "Tap iCLASS SE/Legacy..." :
                                                "Hold card to reader...");
-        canvas_draw_str(canvas, 2, 42, "Scanning...");
+        /* iCLASS mode is ISO15693 (Legacy/SE); Seos is ISO14443-4A — NFC mode. */
+        canvas_draw_str(
+            canvas, 2, 42, app->scan_mode == ScanModeIclass ? "Seos? use NFC mode" : "Scanning...");
         canvas_draw_str(canvas, 2, 52, "< > NFC/RFID/iCLASS");
         canvas_draw_str(canvas, 2, 62, "Up:reports  Back:exit");
         return;

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.11.0"
+#define REPORT_APP_VERSION "1.11.1"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {

--- a/docs/catalog-changelog.md
+++ b/docs/catalog-changelog.md
@@ -1,3 +1,6 @@
+## 1.11.1
+Clarified the iCLASS scan mode: the prompt now reads "Tap iCLASS SE/Legacy..." with a "Seos? use NFC mode" hint. iCLASS Legacy/SE are on ISO 15693; Seos is ISO 14443-4A (NFC mode).
+
 ## 1.11.0
 HID Seos detection: Seos cards (ISO14443-4A) are now identified via an AID SELECT and scored SECURE, instead of showing as a generic ISO 14443-4A card. Passive identify only — reading the PACS still needs a HID SAM.
 


### PR DESCRIPTION
iCLASS mode prompt → `Tap iCLASS SE/Legacy...` + `Seos? use NFC mode` hint. Addresses the brand-vs-radio ambiguity (Legacy/SE = ISO15693; Seos = ISO14443-4A/NFC). Verified on-device. Patch v1.11.1.