### PR TITLE
v1.11.2 — report shows the on-screen verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [1.11.2]: Report shows the on-screen verdict
+
+### Fixed
+- **Report now matches the result screen**: each card's likelihood line shows the on-device verdict in brackets when it differs from the OWASP band — e.g. `Likelihood: MINIMAL [SECURE]`, `Likelihood: HIGH [HIGH RISK]`. Previously the screen said `SECURE`/`HIGH RISK` while the report only said `MINIMAL`/`HIGH`, so the rating appeared to be missing from the report. The verdict words now have a single source of truth in `core/scoring.c` so the screen and report can no longer drift
+
 ## [1.11.1]: Clarify iCLASS scan mode
 
 ### Changed

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.11.1"
+#define APP_VERSION "1.11.2"
 
 #include "access_audit.h"
 #include "core/observation.h"
@@ -133,16 +133,9 @@ static void
 }
 
 static const char* risk_label(Severity severity) {
-    switch(severity) {
-    case SeverityHigh:
-        return "HIGH RISK";
-    case SeverityMedium:
-        return "MODERATE";
-    case SeverityLow:
-        return "LOW RISK";
-    default:
-        return "SECURE";
-    }
+    /* Single source of truth in core/scoring.c so the screen verdict and the
+     * report's bracketed verdict can never drift. */
+    return verdict_label(severity);
 }
 
 static void access_audit_draw_callback(Canvas* canvas, void* context) {

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.11.1"
+#define REPORT_APP_VERSION "1.11.2"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {
@@ -205,13 +205,29 @@ static void write_card_entry(File* f, size_t index, size_t total, const SessionE
         fw(f, buf);
     }
 
-    snprintf(
-        buf,
-        sizeof(buf),
-        "  Likelihood: %s  (%u/100, confidence %u%%)\n",
-        likelihood_label(entry->score.max_severity),
-        entry->score.score,
-        entry->score.confidence);
+    /* Show the OWASP likelihood band, plus the result-screen verdict word in
+     * brackets when it differs (e.g. MINIMAL [SECURE], HIGH [HIGH RISK]) so the
+     * report matches what the user saw on the device. */
+    const char* band = likelihood_label(entry->score.max_severity);
+    const char* verdict = verdict_label(entry->score.max_severity);
+    if(strcmp(band, verdict) != 0) {
+        snprintf(
+            buf,
+            sizeof(buf),
+            "  Likelihood: %s [%s]  (%u/100, confidence %u%%)\n",
+            band,
+            verdict,
+            entry->score.score,
+            entry->score.confidence);
+    } else {
+        snprintf(
+            buf,
+            sizeof(buf),
+            "  Likelihood: %s  (%u/100, confidence %u%%)\n",
+            band,
+            entry->score.score,
+            entry->score.confidence);
+    }
     fw(f, buf);
 
     snprintf(buf, sizeof(buf), "  Ease of exploit: %s\n", ease_of_exploit(&entry->obs));

--- a/core/scoring.c
+++ b/core/scoring.c
@@ -125,6 +125,19 @@ const char* likelihood_label(Severity severity) {
     }
 }
 
+const char* verdict_label(Severity severity) {
+    switch(severity) {
+    case SeverityHigh:
+        return "HIGH RISK";
+    case SeverityMedium:
+        return "MODERATE";
+    case SeverityLow:
+        return "LOW RISK";
+    default:
+        return "SECURE";
+    }
+}
+
 const char* ease_of_exploit(const AccessObservation* obs) {
     if(!obs) return "indeterminate";
     /* A successful default-credential read means the card can be cloned outright. */

--- a/core/scoring.h
+++ b/core/scoring.h
@@ -29,6 +29,11 @@ const char* card_type_to_string(CardType type);
 /* Likelihood band for a severity: HIGH / MODERATE / LOW / MINIMAL. */
 const char* likelihood_label(Severity severity);
 
+/* On-device verdict word for a severity: HIGH RISK / MODERATE / LOW RISK /
+ * SECURE. Mirrors the result-screen label; shown in the report alongside the
+ * likelihood band so the two never drift. */
+const char* verdict_label(Severity severity);
+
 /* OWASP "Ease of Exploit" likelihood factor for a credential:
  * trivial / moderate / hard / indeterminate. */
 const char* ease_of_exploit(const AccessObservation* obs);


### PR DESCRIPTION
Patch release. Fixes the wording mismatch between the result screen and the saved report.

## What changed
- Each card's report line now shows the on-device verdict in brackets when it differs from the OWASP likelihood band:
  - `Likelihood: HIGH [HIGH RISK]`
  - `Likelihood: MODERATE` (unchanged — same word)
  - `Likelihood: LOW [LOW RISK]`
  - `Likelihood: MINIMAL [SECURE]`
- Verdict words centralized in `core/scoring.c` (`verdict_label()`); the screen's `risk_label()` and the report both use it, so they can't drift again.

## Why
A card shown as **SECURE** on the device read `Likelihood: MINIMAL` in the report — the rating looked absent.

## Version
- `APP_VERSION` / `REPORT_APP_VERSION` → 1.11.2
- `fap_version` stays `(1, 11)` — patch, no catalog resubmit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)