### PR TITLE
chore: commit_sha → v1.11.2

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/matthewkayne/flipper-access-audit.git
-    commit_sha: a55b3e06f01e70967d60d5fc0cc6cc249a34358f
+    commit_sha: 4ac716b8282ac0c8e8f3f05d95df04d2dd433526
 author: Matthew Kayne
 description: "@docs/catalog-description.md"
 changelog: "@docs/catalog-changelog.md"


### PR DESCRIPTION
Post-release record update of `manifest.yml` commit_sha to the v1.11.2 release commit (`4ac716b`), per the documented release process. Record-only — no catalog resubmit needed for a patch (fap_version stays 1.11).