### PR TITLE
v1.12.0 — protected Ultralight/NTAG support + air-interface labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project are documented here.
 
+## [1.12.0]: Protected Ultralight/NTAG support + air-interface labels
+
+### Fixed
+- **Password-protected MIFARE Ultralight / NTAG cards no longer hang the scanner**: cards whose user pages are locked (e.g. NTAG213-based hotel keys like VingCard) NAK the page read, which previously left the app looping forever on a read it doesn't need. It now classifies the card from the chip type + UID it already obtained (GET_VERSION + anticollision) and produces a result. Scored as a UID-based (cloneable) credential — HIGH — which is the honest verdict for these cards
+
+### Added
+- **Locked-memory note in reports**: when a card's user memory is password-protected, the report records `user memory is password-protected (pages locked; UID still cloneable)`. Documentation only — it does not change the score (the UID is unprotected and NTAG/UL password auth is sent in cleartext with no mutual auth, so it is not a meaningful access-control control)
+- **Underlying air interface shown alongside the card name**: outputs now include the real protocol next to the friendly name — e.g. `HID Seos (ISO 14443-4A)`, `HID iCLASS (ISO 15693)`, `NTAG213 (ISO 14443-3A)` — in the report always, and on the result screen when it fits
+
 ## [1.11.2]: Report shows the on-screen verdict
 
 ### Fixed

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.11.2"
+#define APP_VERSION "1.12.0"
 
 #include "access_audit.h"
 #include "core/observation.h"
@@ -354,9 +354,19 @@ static void access_audit_draw_callback(Canvas* canvas, void* context) {
 
     canvas_draw_line(canvas, 0, 13, 127, 13);
 
-    /* Card type */
+    /* Card type, with the underlying air interface (e.g. ISO 14443-4A) shown
+     * right-aligned when both fit on the line. */
     canvas_set_font(canvas, FontSecondary);
-    canvas_draw_str(canvas, 2, 24, card_type_to_string(app->obs.card_type));
+    const char* type_name = card_type_to_string(app->obs.card_type);
+    canvas_draw_str(canvas, 2, 24, type_name);
+    const char* type_proto = card_type_protocol(app->obs.card_type);
+    if(type_proto) {
+        uint16_t name_w = canvas_string_width(canvas, type_name);
+        uint16_t proto_w = canvas_string_width(canvas, type_proto);
+        if((uint16_t)(2 + name_w + 6 + proto_w) <= 126) {
+            canvas_draw_str_aligned(canvas, 126, 24, AlignRight, AlignBottom, type_proto);
+        }
+    }
 
     /* Risk label — most prominent element */
     canvas_set_font(canvas, FontPrimary);

--- a/application.fam
+++ b/application.fam
@@ -6,7 +6,7 @@ App(
     sources=["*.c"],
     requires=["gui", "nfc", "storage"],
     stack_size=2 * 1024,
-    fap_version=(1, 11),
+    fap_version=(1, 12),
     fap_icon="icon.png",
     fap_category="Tools",
     fap_author="matthewkayne",

--- a/core/observation.h
+++ b/core/observation.h
@@ -65,6 +65,7 @@ typedef struct {
     bool metadata_complete; /* false when classification could not read all expected fields */
     bool sak_atqa_present; /* true when SAK and ATQA were captured (ISO14443-3A only) */
     bool default_keys_readable; /* true when sector 0 auth succeeded with a default key (Classic only) */
+    bool memory_locked; /* true when user memory is password-protected (Ultralight/NTAG read NAK'd) */
     size_t uid_len;
     uint8_t uid[10];
     uint8_t sak; /* ISO14443-3A Select Acknowledge byte */

--- a/core/observation_provider.c
+++ b/core/observation_provider.c
@@ -511,6 +511,37 @@ static NfcCommand mf_ultralight_poller_cb(NfcGenericEvent event, void* context) 
         } else {
             p->state = ProviderStateReadFailed;
         }
+    } else if(
+        ul_event->type == MfUltralightPollerEventTypeReadFailed ||
+        ul_event->type == MfUltralightPollerEventTypeCardLocked) {
+        /* Password-locked / protected Ultralight (e.g. MIFARE UL EV1 hotel keys
+         * such as VingCard). The page read NAKs, but GET_VERSION + anticollision
+         * already gave us the chip type and UID — classify from those instead of
+         * looping forever on a read we don't need for an audit. The protected
+         * pages are not a "secure element"; for scoring this stays a UID-based
+         * credential (cloneable), which is the honest verdict for these cards. */
+        const MfUltralightData* ul_data = (const MfUltralightData*)nfc_poller_get_data(p->poller);
+        size_t uid_len = 0;
+        const uint8_t* uid = ul_data ? mf_ultralight_get_uid(ul_data, &uid_len) : NULL;
+
+        if(uid && uid_len > 0) {
+            p->pending = (AccessObservation){0};
+            p->pending.tech = TechTypeNfc13Mhz;
+            p->pending.card_type = mf_ultralight_type_to_card_type(ul_data->type);
+            p->pending.metadata_complete = true;
+            p->pending.memory_locked = true;
+
+            p->pending.uid_present = true;
+            p->pending.uid_len = uid_len <= sizeof(p->pending.uid) ? uid_len :
+                                                                     sizeof(p->pending.uid);
+            for(size_t i = 0; i < p->pending.uid_len; i++) {
+                p->pending.uid[i] = uid[i];
+            }
+
+            p->state = ProviderStateDone;
+        } else {
+            p->state = ProviderStateReadFailed;
+        }
     } else {
         p->state = ProviderStateReadFailed;
     }

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.11.2"
+#define REPORT_APP_VERSION "1.12.0"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {
@@ -162,8 +162,22 @@ static void write_card_entry(File* f, size_t index, size_t total, const SessionE
        entry->obs.tech == TechTypeRfid125 ? "  Radio:  RFID 125kHz\n" :
                                             "  Radio:  NFC 13.56MHz\n");
 
-    snprintf(buf, sizeof(buf), "  Type:   %s\n", card_type_to_string(entry->obs.card_type));
+    const char* proto = card_type_protocol(entry->obs.card_type);
+    if(proto) {
+        snprintf(
+            buf,
+            sizeof(buf),
+            "  Type:   %s (%s)\n",
+            card_type_to_string(entry->obs.card_type),
+            proto);
+    } else {
+        snprintf(buf, sizeof(buf), "  Type:   %s\n", card_type_to_string(entry->obs.card_type));
+    }
     fw(f, buf);
+
+    if(entry->obs.memory_locked) {
+        fw(f, "  Note:   user memory is password-protected (pages locked; UID still cloneable)\n");
+    }
 
     /* UID with byte count */
     if(entry->obs.uid_present && entry->obs.uid_len > 0) {

--- a/core/scoring.c
+++ b/core/scoring.c
@@ -268,3 +268,59 @@ const char* card_type_to_string(CardType type) {
         return "Unknown";
     }
 }
+
+const char* card_type_protocol(CardType type) {
+    switch(type) {
+    /* 125 kHz LF — no ISO air-interface number in common use */
+    case CardTypeEm4100Like:
+    case CardTypeHidProxLike:
+    case CardTypeHidGeneric:
+    case CardTypeIndala:
+    case CardTypeRfid125:
+        return "125 kHz";
+    /* ISO 14443-3A (Type A, layer 3 — Classic/Ultralight/NTAG/Plus SL1-2) */
+    case CardTypeMifareClassic:
+    case CardTypeMifareClassic1K:
+    case CardTypeMifareClassic4K:
+    case CardTypeMifareClassicMini:
+    case CardTypeMifareUltralight:
+    case CardTypeMifareUltralightC:
+    case CardTypeNtag203:
+    case CardTypeNtag213:
+    case CardTypeNtag215:
+    case CardTypeNtag216:
+    case CardTypeNtagI2C:
+    case CardTypeMifarePlus:
+    case CardTypeMifarePlusSL1:
+    case CardTypeMifarePlusSL2:
+        return "ISO 14443-3A";
+    /* ISO 14443-4A (Type 4 / ISO 7816 APDUs — DESFire, Plus SL3, Seos) */
+    case CardTypeMifareDesfire:
+    case CardTypeMifareDesfireEV1:
+    case CardTypeMifareDesfireEV2:
+    case CardTypeMifareDesfireEV3:
+    case CardTypeMifareDesfireLight:
+    case CardTypeMifarePlusSL3:
+    case CardTypeSeos:
+        return "ISO 14443-4A";
+    case CardTypeIso14443A:
+        return "ISO 14443-A";
+    case CardTypeIso14443B:
+    case CardTypeSt25tb:
+        return "ISO 14443-B";
+    /* ISO 15693 — also the air interface for HID iCLASS / PicoPass */
+    case CardTypeIso15693:
+    case CardTypeHidIclass:
+    case CardTypeHidIclassLegacy:
+    case CardTypeHidIclassLegacy2k:
+    case CardTypeHidIclassLegacy16k:
+    case CardTypeHidIclassLegacy32k:
+    case CardTypeSlix:
+        return "ISO 15693";
+    case CardTypeFelica:
+    case CardTypeFeliCaLite:
+        return "JIS X 6319-4 (FeliCa)";
+    default:
+        return NULL;
+    }
+}

--- a/core/scoring.h
+++ b/core/scoring.h
@@ -20,6 +20,12 @@ AuditScore score_observation(const AccessObservation* obs);
 const char* severity_to_string(Severity severity);
 const char* card_type_to_string(CardType type);
 
+/* Underlying air-interface standard for a card type (e.g. "ISO 14443-4A" for
+ * HID Seos, "ISO 15693" for iCLASS, "125 kHz" for LF). Returned alongside the
+ * friendly name in outputs so the real protocol is always documented. NULL for
+ * Unknown. */
+const char* card_type_protocol(CardType type);
+
 /* OWASP Risk Rating Methodology framing
  * (https://owasp.org/www-community/OWASP_Risk_Rating_Methodology): the score is
  * a LIKELIHOOD-of-compromise rating only — how easily the credential technology

--- a/docs/catalog-changelog.md
+++ b/docs/catalog-changelog.md
@@ -1,3 +1,9 @@
+## 1.12.0
+Password-protected MIFARE Ultralight and NTAG cards (such as NTAG213-based hotel keys) no longer hang the scanner — they are now classified from the chip type and UID and scored HIGH (UID-cloneable). Reports note when user memory is password-protected. Outputs now show the underlying air interface next to the card name, e.g. "HID Seos (ISO 14443-4A)", "HID iCLASS (ISO 15693)", "NTAG213 (ISO 14443-3A)".
+
+## 1.11.2
+The report now shows the on-screen verdict word alongside the OWASP likelihood band, e.g. "Likelihood: MINIMAL [SECURE]" and "Likelihood: HIGH [HIGH RISK]", so the saved report matches what the device displays.
+
 ## 1.11.1
 Clarified the iCLASS scan mode: the prompt now reads "Tap iCLASS SE/Legacy..." with a "Seos? use NFC mode" hint. iCLASS Legacy/SE are on ISO 15693; Seos is ISO 14443-4A (NFC mode).
 


### PR DESCRIPTION
Minor release.

## Fixed
- **Password-protected MIFARE Ultralight / NTAG cards no longer hang the scanner.** Cards whose user pages are locked (e.g. NTAG213-based hotel keys like VingCard) NAK the page read; the app previously looped forever on a read it doesn't need. It now classifies from the chip type + UID it already has (GET_VERSION + anticollision) and produces a result, scored **HIGH** (UID-based / cloneable) — the honest verdict for these cards.

## Added
- **Locked-memory note in reports** when user memory is password-protected: `user memory is password-protected (pages locked; UID still cloneable)`. Documentation only — **no score change** (the UID is unprotected and NTAG/UL password auth is sent in cleartext with no mutual auth, so crediting it would be false reassurance).
- **Underlying air interface alongside the card name** — `HID Seos (ISO 14443-4A)`, `HID iCLASS (ISO 15693)`, `NTAG213 (ISO 14443-3A)`, etc. — in the report always, and on the result screen when it fits.

## Version
- `fap_version` → `(1, 12)` (catalog-eligible minor)
- `APP_VERSION` / `REPORT_APP_VERSION` → 1.12.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)