### PR TITLE
v1.13.0 — all-sector Classic default-key sweep + Ultralight factory-password check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented here.
 
+## [1.13.0]: Deeper default-credential checks
+
+### Added
+- **MIFARE Classic all-sector default-key sweep**: when sector 0 still uses a default key, the scan now sweeps every sector and reports `N/M sectors use default keys` (screen + report), instead of only flagging sector 0. A re-keyed sector 0 (managed card) still returns fast — the deep sweep is gated on sector 0 being default. Closes #34
+- **MIFARE Ultralight / NTAG factory-password check**: tests the factory password `FFFFFFFF` and reports when it is accepted (`memory effectively unprotected`). **Config-gated and non-destructive**: the password is only sent when the card exposes its config and has no failed-auth lockout (`AUTHLIM == 0`), so a wrong guess can never trip a lockout. Closes #33
+- Expanded the MIFARE Classic default-key dictionary to the full mfoc/Proxmark public set (added `4D3A99C351DD` and `1A982C7E459A`)
+
+### Changed
+- The result screen's bottom row always shows the controls hint, now corrected to `OK:rescan  Back:save` (Back saves the session report). All findings — default keys `N/M`, factory password, password-locked memory — are recorded in the saved report
+
 ## [1.12.0]: Protected Ultralight/NTAG support + air-interface labels
 
 ### Fixed

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.12.0"
+#define APP_VERSION "1.13.0"
 
 #include "access_audit.h"
 #include "core/observation.h"
@@ -381,14 +381,12 @@ static void access_audit_draw_callback(Canvas* canvas, void* context) {
     access_audit_format_uid_line(&app->obs, line, sizeof(line));
     canvas_draw_str(canvas, 2, 48, line);
 
-    /* Bottom row: surface the active-scan default-key finding when present,
-     * otherwise show the controls hint. The finding is the more important
-     * signal and would otherwise only appear in the saved report. */
-    if(app->obs.default_keys_readable) {
-        canvas_draw_str(canvas, 2, 62, "! Default key readable");
-    } else {
-        canvas_draw_str(canvas, 2, 62, "OK:rescan  Back:exit");
-    }
+    /* Bottom row always shows the controls hint. Findings (default keys N/M,
+     * factory password, password-locked memory, etc.) are recorded in the saved
+     * report — nothing evicts the controls hint. The risk label + score above
+     * already convey severity at a glance. Back goes to name-entry/save (the
+     * session always has the just-scanned card here), not a bare exit. */
+    canvas_draw_str(canvas, 2, 62, "OK:rescan  Back:save");
 }
 
 static void access_audit_input_callback(InputEvent* input_event, void* context) {

--- a/application.fam
+++ b/application.fam
@@ -6,7 +6,7 @@ App(
     sources=["*.c"],
     requires=["gui", "nfc", "storage"],
     stack_size=2 * 1024,
-    fap_version=(1, 12),
+    fap_version=(1, 13),
     fap_icon="icon.png",
     fap_category="Tools",
     fap_author="matthewkayne",

--- a/core/observation.h
+++ b/core/observation.h
@@ -66,6 +66,9 @@ typedef struct {
     bool sak_atqa_present; /* true when SAK and ATQA were captured (ISO14443-3A only) */
     bool default_keys_readable; /* true when sector 0 auth succeeded with a default key (Classic only) */
     bool memory_locked; /* true when user memory is password-protected (Ultralight/NTAG read NAK'd) */
+    bool default_password_readable; /* Ultralight/NTAG: factory password (FFFFFFFF) accepted */
+    uint8_t default_key_sectors; /* MIFARE Classic: count of sectors found on a default key */
+    uint8_t total_sectors; /* MIFARE Classic: total sectors on the card (0 if unknown) */
     size_t uid_len;
     uint8_t uid[10];
     uint8_t sak; /* ISO14443-3A Select Acknowledge byte */

--- a/core/observation_provider.c
+++ b/core/observation_provider.c
@@ -70,6 +70,8 @@ struct ObservationProvider {
     NfcProtocol uid_protocol;
     /* Populated by poller callback */
     AccessObservation pending;
+    /* Worker-thread-only: set when the Ultralight/NTAG default password auths. */
+    bool ul_default_pwd_ok;
 };
 
 /* -------------------------------------------------------------------------
@@ -465,8 +467,11 @@ static NfcCommand iso14443_3a_poller_cb(NfcGenericEvent event, void* context) {
 /* -------------------------------------------------------------------------
  * MfUltralight poller callback  (runs on NFC worker thread)
  *
- * The poller fires RequestMode first (we ask for Read), then AuthRequest if
- * the card requires a password (we skip it), then ReadSuccess/ReadFailed.
+ * The poller fires RequestMode first (we ask for Read), then AuthRequest if the
+ * card requires a password. We test the factory password FFFFFFFF only when the
+ * config is readable and no AUTHLIM lockout is configured (non-destructive);
+ * otherwise we skip auth. Then ReadSuccess (incl. after a successful default-
+ * password auth) or ReadFailed/CardLocked (protected — salvage type + UID).
  * -------------------------------------------------------------------------
  */
 
@@ -477,10 +482,32 @@ static NfcCommand mf_ultralight_poller_cb(NfcGenericEvent event, void* context) 
     /* These two events don't touch shared provider state — no mutex needed. */
     if(ul_event->type == MfUltralightPollerEventTypeRequestMode) {
         ul_event->data->poller_mode = MfUltralightPollerModeRead;
+        p->ul_default_pwd_ok = false; /* reset per scan */
         return NfcCommandContinue;
     }
     if(ul_event->type == MfUltralightPollerEventTypeAuthRequest) {
-        ul_event->data->auth_context.skip_auth = true;
+        /* Config-gated default-password test (non-destructive): only send the
+         * factory password FFFFFFFF if the card exposes its config pages AND has
+         * no failed-auth lockout (AUTHLIM == 0), so a wrong guess can never trip
+         * a lockout / brick the card. Otherwise skip auth entirely. */
+        const MfUltralightData* cfg_data = (const MfUltralightData*)nfc_poller_get_data(p->poller);
+        MfUltralightConfigPages* cfg = NULL;
+        bool safe_to_test = cfg_data && mf_ultralight_get_config_page(cfg_data, &cfg) && cfg &&
+                            cfg->access.authlim == 0;
+        if(safe_to_test) {
+            ul_event->data->auth_context.skip_auth = false;
+            memset(
+                ul_event->data->auth_context.password.data,
+                0xFF,
+                sizeof(ul_event->data->auth_context.password.data));
+        } else {
+            ul_event->data->auth_context.skip_auth = true;
+        }
+        return NfcCommandContinue;
+    }
+    if(ul_event->type == MfUltralightPollerEventTypeAuthSuccess) {
+        /* The factory password (FFFFFFFF) we supplied was accepted. */
+        p->ul_default_pwd_ok = true;
         return NfcCommandContinue;
     }
 
@@ -497,6 +524,7 @@ static NfcCommand mf_ultralight_poller_cb(NfcGenericEvent event, void* context) 
             p->pending.tech = TechTypeNfc13Mhz;
             p->pending.card_type = mf_ultralight_type_to_card_type(ul_data->type);
             p->pending.metadata_complete = true;
+            p->pending.default_password_readable = p->ul_default_pwd_ok;
 
             if(uid && uid_len > 0) {
                 p->pending.uid_present = true;
@@ -653,16 +681,54 @@ static NfcCommand mf_plus_poller_cb(NfcGenericEvent event, void* context) {
     return NfcCommandStop;
 }
 
+/* Well-known public MIFARE Classic keys, each tried as both key A and key B.
+ * Covers the standard mfoc / Proxmark3 default-key set (incl. 4D3A99C351DD and
+ * 1A982C7E459A) plus the NXP MAD / NFC Forum NDEF keys and common vendor
+ * defaults. Kept small so the per-sector auth sweep stays fast. */
+static const uint8_t MF_CLASSIC_DEFAULT_KEYS[][MF_CLASSIC_KEY_SIZE] = {
+    {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, /* FFFFFFFFFFFF — factory transport default */
+    {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5}, /* A0A1A2A3A4A5 — MAD key A (NXP AN10787)   */
+    {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7}, /* D3F7D3F7D3F7 — NFC Forum NDEF public key */
+    {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, /* 000000000000 — blanked / all-zero key    */
+    {0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0}, /* A0B0C0D0E0F0 — common vendor default      */
+    {0xA1, 0xB1, 0xC1, 0xD1, 0xE1, 0xF1}, /* A1B1C1D1E1F1 — common vendor default      */
+    {0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5}, /* B0B1B2B3B4B5 — common vendor default      */
+    {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}, /* AABBCCDDEEFF — common vendor default      */
+    {0x4D, 0x3A, 0x99, 0xC3, 0x51, 0xDD}, /* 4D3A99C351DD — mfoc/Proxmark public key   */
+    {0x1A, 0x98, 0x2C, 0x7E, 0x45, 0x9A}, /* 1A982C7E459A — mfoc/Proxmark public key   */
+};
+static const MfClassicKeyType MF_CLASSIC_KEY_TYPES[] = {MfClassicKeyTypeA, MfClassicKeyTypeB};
+
+/* Try every default key (as key A and key B) against the sector that contains
+ * block_num. Returns true at the first key that authenticates. Re-activates the
+ * card on each attempt (skip_module_activation=false) so it is safe to call
+ * across sectors in sequence. */
+static bool mf_classic_block_has_default_key(MfClassicPoller* poller, uint8_t block_num) {
+    const size_t num_keys = sizeof(MF_CLASSIC_DEFAULT_KEYS) / sizeof(MF_CLASSIC_DEFAULT_KEYS[0]);
+    const size_t num_types = sizeof(MF_CLASSIC_KEY_TYPES) / sizeof(MF_CLASSIC_KEY_TYPES[0]);
+    for(size_t k = 0; k < num_keys; k++) {
+        for(size_t t = 0; t < num_types; t++) {
+            MfClassicKey key;
+            memcpy(key.data, MF_CLASSIC_DEFAULT_KEYS[k], MF_CLASSIC_KEY_SIZE);
+            MfClassicAuthContext auth_ctx;
+            if(mf_classic_poller_auth(
+                   poller, block_num, &key, MF_CLASSIC_KEY_TYPES[t], &auth_ctx, false) ==
+               MfClassicErrorNone) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 /* -------------------------------------------------------------------------
  * MfClassic poller callback  (runs on NFC worker thread)
  *
  * Uses MfClassicPollerModeRead. The poller fires RequestReadSector starting
- * from sector 0. On that event we manually call mf_classic_poller_auth against
- * a list of well-known public keys (each tried as both key A and key B) and
- * record whether any succeeded. We then halt the card and stop — no full sector
- * read is performed and no card data is retained. The loop stops at the first
- * key that authenticates. See DEFAULT_KEYS below for the full list (factory
- * transport, NXP MAD, NFC Forum NDEF, and common vendor defaults).
+ * from sector 0. Sector 0 (the access-control sector) is always tested against
+ * the default-key list; only if it still uses a default key do we sweep the
+ * remaining sectors and count how many are on default keys (N/M). A re-keyed
+ * sector 0 means a managed card and returns fast. No sector data is retained.
  * -------------------------------------------------------------------------
  */
 
@@ -690,41 +756,26 @@ static NfcCommand mf_classic_poller_cb(NfcGenericEvent event, void* context) {
 
     if(cl_event->type == MfClassicPollerEventTypeRequestReadSector &&
        cl_event->data->read_sector_request_data.sector_num == 0) {
-        /* Well-known public MIFARE Classic keys checked against sector 0.
-         * Each is tried as both key A and key B. Kept under 10 so the auth
-         * loop stays fast; these cover the keys overwhelmingly seen in the
-         * field on cards that were never re-keyed. */
-        static const uint8_t DEFAULT_KEYS[][MF_CLASSIC_KEY_SIZE] = {
-            {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, /* FFFFFFFFFFFF — factory transport default */
-            {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5}, /* A0A1A2A3A4A5 — MAD key A (NXP AN10787)   */
-            {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7}, /* D3F7D3F7D3F7 — NFC Forum NDEF public key */
-            {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, /* 000000000000 — blanked / all-zero key    */
-            {0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0}, /* A0B0C0D0E0F0 — common vendor default      */
-            {0xA1, 0xB1, 0xC1, 0xD1, 0xE1, 0xF1}, /* A1B1C1D1E1F1 — common vendor default      */
-            {0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5}, /* B0B1B2B3B4B5 — common vendor default      */
-            {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}, /* AABBCCDDEEFF — common vendor default      */
-        };
-        static const MfClassicKeyType KEY_TYPES[] = {MfClassicKeyTypeA, MfClassicKeyTypeB};
-        const size_t num_keys = sizeof(DEFAULT_KEYS) / sizeof(DEFAULT_KEYS[0]);
-        const size_t num_key_types = sizeof(KEY_TYPES) / sizeof(KEY_TYPES[0]);
-
         MfClassicPoller* cl_poller = (MfClassicPoller*)event.instance;
-        MfClassicAuthContext auth_ctx;
-        bool default_key_found = false;
 
-        for(size_t k = 0; k < num_keys && !default_key_found; k++) {
-            for(size_t t = 0; t < num_key_types && !default_key_found; t++) {
-                MfClassicKey key;
-                memcpy(key.data, DEFAULT_KEYS[k], MF_CLASSIC_KEY_SIZE);
-                MfClassicError err =
-                    mf_classic_poller_auth(cl_poller, 0, &key, KEY_TYPES[t], &auth_ctx, false);
-                if(err == MfClassicErrorNone) default_key_found = true;
+        /* Card type → sector count (read before auth; the data buffer stays
+         * valid afterwards for UID/SAK/ATQA). */
+        const MfClassicData* cl_data = (const MfClassicData*)nfc_poller_get_data(p->poller);
+        uint8_t total_sectors = cl_data ? mf_classic_get_total_sectors_num(cl_data->type) : 0;
+
+        /* Always test sector 0 against the full key list. Only if it is still on
+         * a default key do we sweep the remaining sectors and count how many use
+         * default keys — a re-keyed sector 0 (managed card) returns fast. */
+        bool default_key_found = mf_classic_block_has_default_key(cl_poller, 0);
+        uint8_t default_key_sectors = default_key_found ? 1 : 0;
+        if(default_key_found) {
+            for(uint8_t s = 1; s < total_sectors; s++) {
+                uint8_t block = mf_classic_get_first_block_num_of_sector(s);
+                if(mf_classic_block_has_default_key(cl_poller, block)) default_key_sectors++;
             }
         }
 
         mf_classic_poller_halt(cl_poller);
-
-        const MfClassicData* cl_data = (const MfClassicData*)nfc_poller_get_data(p->poller);
 
         furi_mutex_acquire(p->mutex, FuriWaitForever);
 
@@ -737,6 +788,8 @@ static NfcCommand mf_classic_poller_cb(NfcGenericEvent event, void* context) {
             p->pending.tech = TechTypeNfc13Mhz;
             p->pending.metadata_complete = true;
             p->pending.default_keys_readable = default_key_found;
+            p->pending.total_sectors = total_sectors;
+            p->pending.default_key_sectors = default_key_sectors;
 
             if(iso_data) {
                 uint8_t sak = iso14443_3a_get_sak(iso_data);

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.12.0"
+#define REPORT_APP_VERSION "1.13.0"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {
@@ -178,6 +178,9 @@ static void write_card_entry(File* f, size_t index, size_t total, const SessionE
     if(entry->obs.memory_locked) {
         fw(f, "  Note:   user memory is password-protected (pages locked; UID still cloneable)\n");
     }
+    if(entry->obs.default_password_readable) {
+        fw(f, "  Note:   factory password FFFFFFFF accepted -- memory effectively unprotected\n");
+    }
 
     /* UID with byte count */
     if(entry->obs.uid_present && entry->obs.uid_len > 0) {
@@ -283,9 +286,19 @@ static void write_card_entry(File* f, size_t index, size_t total, const SessionE
 
     /* Default key finding - explicit note when confirmed via active scan */
     if(rule_default_keys(&entry->obs)) {
-        fw(f,
-           "  Note:   Sector 0 readable with a default key (active scan). "
-           "Keys have never been changed.\n");
+        if(entry->obs.total_sectors > 0) {
+            snprintf(
+                buf,
+                sizeof(buf),
+                "  Note:   %u/%u sectors use default keys (active scan)\n",
+                (unsigned)entry->obs.default_key_sectors,
+                (unsigned)entry->obs.total_sectors);
+            fw(f, buf);
+        } else {
+            fw(f,
+               "  Note:   Sector 0 readable with a default key (active scan). "
+               "Keys have never been changed.\n");
+        }
     }
 
     fw(f, "\n");

--- a/docs/catalog-changelog.md
+++ b/docs/catalog-changelog.md
@@ -1,3 +1,6 @@
+## 1.13.0
+Deeper default-credential checks. MIFARE Classic: when sector 0 still uses a default key, the scan now sweeps every sector and reports how many of N sectors use default keys (the dictionary was also expanded to the full mfoc/Proxmark public set). MIFARE Ultralight and NTAG: the scan now tests the factory password FFFFFFFF and reports when it is accepted, but only when the card exposes its config and has no failed-auth lockout configured, so the test can never lock a card. The result screen keeps its controls hint at all times; all findings are written to the saved report.
+
 ## 1.12.0
 Password-protected MIFARE Ultralight and NTAG cards (such as NTAG213-based hotel keys) no longer hang the scanner — they are now classified from the chip type and UID and scored HIGH (UID-cloneable). Reports note when user memory is password-protected. Outputs now show the underlying air interface next to the card name, e.g. "HID Seos (ISO 14443-4A)", "HID iCLASS (ISO 15693)", "NTAG213 (ISO 14443-3A)".
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -85,10 +85,20 @@ Keys checked (key A and key B for each):
 - `A1B1C1D1E1F1` - common vendor default
 - `B0B1B2B3B4B5` - common vendor default
 - `AABBCCDDEEFF` - common vendor default
+- `4D3A99C351DD` - mfoc / Proxmark public key
+- `1A982C7E459A` - mfoc / Proxmark public key
 
-The list is intentionally capped (under 10 keys) so the active auth loop completes quickly. The check stops at the first key that authenticates. This rule requires an active authentication attempt. A note is written to the report indicating the finding came from an active scan.
+The check stops at the first key that authenticates per sector. Sector 0 is always tested; **only if sector 0 uses a default key** are the remaining sectors swept, and the report records how many of the card's N sectors are on default keys (`N/M sectors use default keys`). A re-keyed sector 0 returns immediately (no full sweep). This rule requires an active authentication attempt; a note is written to the report indicating the finding came from an active scan.
 
-**Score contribution:** +15 · **Max severity:** HIGH
+**Score contribution:** +15 · **Max severity:** HIGH (the all-sector count is reporting detail and does not change the score)
+
+---
+
+### `default_password` (Ultralight / NTAG)
+
+A report-only finding (not a scoring rule). On MIFARE Ultralight / NTAG cards the scan tests the factory password `FFFFFFFF`; if it is accepted, the report notes that memory is effectively unprotected.
+
+**Non-destructive gate:** the password is sent only when the card exposes its config pages **and** has no failed-auth lockout configured (`AUTHLIM == 0`), so a wrong guess can never trip a lockout. When a lockout is set (or config is unreadable) the test is skipped and the card is reported as password-protected without sending anything. The card is already scored HIGH (UID-cloneable, no mutual auth), so this finding does not change the score.
 
 ---
 


### PR DESCRIPTION
Minor release. Deeper default-credential checks.

## Added
- **MIFARE Classic all-sector default-key sweep** — when sector 0 still uses a default key, every sector is swept and the report shows `N/M sectors use default keys`. Gated on sector 0 being default, so a re-keyed (managed) card returns fast. **Closes #34**
- **MIFARE Ultralight / NTAG factory-password check** — tests `FFFFFFFF` and reports when accepted. **Config-gated & non-destructive**: only sent when the card exposes its config and `AUTHLIM == 0`, so a wrong guess can never trip a lockout. **Closes #33**
- Expanded the Classic dictionary to the full mfoc/Proxmark public set (`4D3A99C351DD`, `1A982C7E459A`).

## Changed
- Result screen always keeps the controls hint, corrected to `OK:rescan  Back:save`. All findings (default keys `N/M`, factory password, password-locked memory) are recorded in the saved report.
- Scoring unchanged — the affected cards are already HIGH; the new signals are reporting detail.

## Version
- `fap_version` → `(1, 13)`; `APP_VERSION` / `REPORT_APP_VERSION` → 1.13.0

Closes #33
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)