### PR TITLE
v1.13.1 — fix 125 kHz read crash + right-arrow redraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented here.
 
+## [1.13.1]: Fix 125 kHz read crash
+
+### Fixed
+- **Crash reading some 125 kHz cards**: `protocol_dict_get_data()` requires the destination buffer to hold the protocol's full data size, but the reader passed a size clamped to the UID field — so any 125 kHz protocol with more than 10 bytes of data (extended HID, Indala, etc.) aborted the firmware. The reader now reads into a full-size buffer and keeps the first bytes as the UID
+- **Scan screen: the right arrow now redraws** — both left and right arrows visibly cycle NFC/RFID/iCLASS (the right arrow already changed the mode but was missing a screen refresh, so it looked inert)
+
 ## [1.13.0]: Deeper default-credential checks
 
 ### Added

--- a/access_audit.c
+++ b/access_audit.c
@@ -2,7 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 
-#define APP_VERSION "1.13.0"
+#define APP_VERSION "1.13.1"
 
 #include "access_audit.h"
 #include "core/observation.h"
@@ -485,6 +485,7 @@ int32_t access_audit_app(void* p) {
                         else
                             app->scan_mode = ScanModeNfc;
                         access_audit_start_scanning(app);
+                        view_port_update(app->view_port);
                     } else if(event.input.key == InputKeyLeft) {
                         access_audit_stop_scanning(app);
                         if(app->scan_mode == ScanModeNfc)

--- a/core/report.c
+++ b/core/report.c
@@ -11,7 +11,7 @@
 #define TAG "AccessAudit"
 
 #define REPORT_DIR         "/ext/apps_data/access_audit"
-#define REPORT_APP_VERSION "1.13.0"
+#define REPORT_APP_VERSION "1.13.1"
 
 /* Write a plain C string to the file. */
 static void fw(File* f, const char* s) {

--- a/core/rfid_provider.c
+++ b/core/rfid_provider.c
@@ -69,12 +69,21 @@ static void
     p->pending.card_type = lfrfid_protocol_to_card_type((LFRFIDProtocol)protocol);
     p->pending.metadata_complete = true;
 
-    /* Pull the raw data bytes and use them as the UID. */
+    /* Pull the raw data bytes and use them as the UID.
+     *
+     * protocol_dict_get_data() requires the destination buffer to hold the
+     * protocol's FULL data size — it asserts on a smaller buffer and then copies
+     * the full size. Passing the clamped copy_size crashed the firmware on any
+     * 125 kHz protocol whose data exceeds sizeof(uid) (e.g. extended HID,
+     * Indala). Read into a full-size temp buffer, then keep the first bytes as
+     * the UID, clamped to the uid field. */
     size_t data_size = protocol_dict_get_data_size(p->dict, (size_t)protocol);
-    if(data_size > 0) {
+    uint8_t tmp[64];
+    if(data_size > 0 && data_size <= sizeof(tmp)) {
+        protocol_dict_get_data(p->dict, (size_t)protocol, tmp, data_size);
         size_t copy_size = data_size <= sizeof(p->pending.uid) ? data_size :
                                                                  sizeof(p->pending.uid);
-        protocol_dict_get_data(p->dict, (size_t)protocol, p->pending.uid, copy_size);
+        memcpy(p->pending.uid, tmp, copy_size);
         p->pending.uid_present = true;
         p->pending.uid_len = copy_size;
     }

--- a/docs/catalog-changelog.md
+++ b/docs/catalog-changelog.md
@@ -1,3 +1,6 @@
+## 1.13.1
+Fixes a crash when reading some 125 kHz cards (protocols with more than 10 bytes of data, such as extended HID or Indala). Also fixes the scan screen so both the left and right arrows visibly cycle NFC/RFID/iCLASS.
+
 ## 1.13.0
 Deeper default-credential checks. MIFARE Classic: when sector 0 still uses a default key, the scan now sweeps every sector and reports how many of N sectors use default keys (the dictionary was also expanded to the full mfoc/Proxmark public set). MIFARE Ultralight and NTAG: the scan now tests the factory password FFFFFFFF and reports when it is accepted, but only when the card exposes its config and has no failed-auth lockout configured, so the test can never lock a card. The result screen keeps its controls hint at all times; all findings are written to the saved report.
 


### PR DESCRIPTION
Patch release addressing catalog-review feedback (xMasterX, PR flipperdevices/flipper-application-catalog#1112).

## Fixed
- **Crash reading some 125 kHz cards.** `protocol_dict_get_data()` requires the destination buffer to hold the protocol's full data size; we passed a size clamped to `uid[10]`, so any 125 kHz protocol with >10 bytes (extended HID, Indala, FDX-style) aborted the firmware. Now reads into a full-size temp buffer and keeps the first bytes as the UID.
- **Scan screen right arrow now redraws** — it already changed the mode but lacked a `view_port_update()`, so it looked inert. Both arrows now visibly cycle NFC/RFID/iCLASS.

## Version
- Patch: `fap_version` stays `(1, 13)`; `APP_VERSION`/`REPORT_APP_VERSION` → 1.13.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)