### PR TITLE
chore: commit_sha → v1.13.1

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/matthewkayne/flipper-access-audit.git
-    commit_sha: cf0447b65364ff246791c0de1e4ab902b41ec21f
+    commit_sha: c398b0d2823ec1279cfdc004f3881525d62f2d8d
 author: Matthew Kayne
 description: "@docs/catalog-description.md"
 changelog: "@docs/catalog-changelog.md"


### PR DESCRIPTION
Post-release record update to the v1.13.1 release commit (c398b0d).